### PR TITLE
Update link to the RPM Guide

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -15,7 +15,7 @@ This page attempts to track the various relevant documentation that exists for R
 
 ## Packager Documentation
 * [Fedora RPM Guide](http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/index.html)
-* [RPM Guide](http://rpm-guide.readthedocs.io) - A Good introduction into RPM Packaging
+* [RPM Guide](https://rpm-packaging-guide.github.io/) - A Good introduction into RPM Packaging
 * On rpm.org about special topics:
   * [Conditional Builds (rpmbuild &#8211;&#8211;with/&#8211;&#8211;without)](user_doc/conditional_builds.html)
   * [Dependencies](user_doc/dependencies.html)


### PR DESCRIPTION
The previous link to readthedocs.io has a link at the top redirecting to github.io.

Updating the link on this page to the maintained page.