### PR TITLE
Add OrderWithRequires generators

### DIFF
--- a/user_doc/dependency_generators.md
+++ b/user_doc/dependency_generators.md
@@ -17,6 +17,7 @@ A file attribute is represented by a macro file in `%{_fileattrsdir}` (typically
 %__NAME_conflicts
 %__NAME_enhances
 %__NAME_obsoletes
+%__NAME_orderwithrequires
 %__NAME_provides
 %__NAME_requires
 %__NAME_recommends
@@ -50,6 +51,7 @@ This way the generator can be implemented in whatever language is preferred and 
 %__NAME_conflicts
 %__NAME_enhances
 %__NAME_obsoletes
+%__NAME_orderwithrequires
 %__NAME_provides
 %__NAME_requires
 %__NAME_recommends
@@ -57,12 +59,15 @@ This way the generator can be implemented in whatever language is preferred and 
 %__NAME_supplements
 ```
 
+Note that generating `OrderWithRequires` will appear only in rpm >= 4.17.
+
 The value is the command line of the generator script/executable and any arguments that should be passed to it. In addition to what's defined in the provides/requires macros, it's possible to pass additional arbitrary switches to generators by defining the following macros:
 
 ```
 %__NAME_conflicts_opts
 %__NAME_enhances_opts
 %__NAME_obsoletes_opts
+%__NAME_orderwithrequires_opts
 %__NAME_provides_opts
 %__NAME_requires_opts
 %__NAME_recommends_opts


### PR DESCRIPTION
Added by commits:
https://github.com/rpm-software-management/rpm/commit/32e2bc50cff9db05729349ff6645a0251d5719fb
https://github.com/rpm-software-management/rpm/commit/e16672805fb57f7688c5e288e5d8b5c5baf4192b

I am not sure that "generating `OrderWithRequires` will appear only in rpm >= 4.17", but it is probably so.