### PR TITLE
Fix links and use https where appropriate

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@ Released   : 20100423
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title>{{ page.title }}</title>
 <link href="{{ site.baseurl }}/stylesheets/style.css" rel="stylesheet" type="text/css" media="screen" />
-<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+<link rel="shortcut icon" type="image/x-icon" href="{{ site.baseurl }}/favicon.ico">
 </head>
 <body>
 <div id="wrapper">

--- a/devel_doc/release_maintaince.md
+++ b/devel_doc/release_maintaince.md
@@ -46,7 +46,7 @@ If the answer to any of the above is "yes" then its almost certainly not appropr
 
 ## Cutting a release
 
-1. Prepare preliminary release notes at http://rpm.org/wiki/Releases/X.Y.Z
+1. Prepare preliminary release notes at https://rpm.org/wiki/Releases/X.Y.Z
 
     * Not every commit needs a corresponding release notes entry, eg
       internal refactoring and cleanup should not be detailed, and 
@@ -102,5 +102,5 @@ If the answer to any of the above is "yes" then its almost certainly not appropr
 9. Make the release official:
 
     * add tarball checksum and download location to the release notes
-    * add a new item to http://rpm.org/wiki/News and http://rpm.org/timeline
+    * add a new item to https://rpm.org/wiki/News and https://rpm.org/timeline
     * send an announcement mail to rpm-announce@lists.rpm.org and rpm-maint@lists.rpm.org (and why not rpm-list@lists.rpm.org too) 

--- a/documentation.md
+++ b/documentation.md
@@ -31,12 +31,12 @@ This page attempts to track the various relevant documentation that exists for R
 
 ## RPM API
 * API documentation
-  * [RPM 4.16.x](http://ftp.rpm.org/api/4.16.1/)
-  * [RPM 4.15.x](http://ftp.rpm.org/api/4.15.1/)
-  * [RPM 4.14.x](http://ftp.rpm.org/api/4.14.0/)
-  * [RPM 4.13.x](http://ftp.rpm.org/api/4.13.0/)
-  * [RPM 4.12.x](http://ftp.rpm.org/api/4.12.0.1/)
-  * [Older versions](http://ftp.rpm.org/api/)
+  * [RPM 4.16.x](https://ftp.osuosl.org/pub/rpm/api/4.16.1/)
+  * [RPM 4.15.x](https://ftp.osuosl.org/pub/rpm/api/4.15.1/)
+  * [RPM 4.14.x](https://ftp.osuosl.org/pub/rpm/api/4.14.0/)
+  * [RPM 4.13.x](https://ftp.osuosl.org/pub/rpm/api/4.13.0/)
+  * [RPM 4.12.x](https://ftp.osuosl.org/pub/rpm/api/4.12.0.1/)
+  * [Older versions](https://ftp.osuosl.org/pub/rpm/api/)
 
 * [Plugin Interface (RPM >= 4.12)](devel_doc/plugins.html)
 * [Programming RPM with C](http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-programming-c.html) from Fedora RPM Guide
@@ -56,7 +56,7 @@ This page attempts to track the various relevant documentation that exists for R
 ## Books
 The following books have been published regarding RPM:
 
-* **Maximum RPM** A book written by Ed Bailey. It is available in hardback (442 pages), and has recently been re-printed by Sams in soft-cover (450 pages - ISBN: 0672311054). The hardcover edition includes a quick reference card. An on-line version of the original book is also available, and a more up to date, work in progress version can be found [here](http://ftp.rpm.org/max-rpm/). 
+* **Maximum RPM** A book written by Ed Bailey. It is available in hardback (442 pages), and has recently been re-printed by Sams in soft-cover (450 pages - ISBN: 0672311054). The hardcover edition includes a quick reference card. An on-line version of the original book is also available, and a more up to date, work in progress version can be found [here](https://ftp.osuosl.org/pub/rpm/max-rpm/). 
 * **Red Hat RPM Guide** A more recent book by Eric Foster-Johnson, this has recently been released under the Open Publication License and a draft close to the published version is available on-line as [Fedora RPM Guide](http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/index.html). This book covers everything from basic usage to advanced tricks, package creation and API programming. Participation in updating the Guide can be done via the [Fedora Documentation Project](http://fedoraproject.org/wiki/DocsProject). Discussions about moving this content and work upstream to rpm.org can occur on [fedora-docs-list](http://www.redhat.com/mailman/listinfo/fedora-docs-list). 
 
 ## Other Resources

--- a/download.md
+++ b/download.md
@@ -6,15 +6,15 @@ title: rpm.org - Download
 ## Current stable releases (supported)
 
 ### RPM 4.16.x
-* [RPM 4.16.1.3](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.3.tar.bz2) ([Release notes](wiki/Releases/4.16.1.3.html))
-* [RPM 4.16.1.2](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.2.tar.bz2) ([Release notes](wiki/Releases/4.16.1.2.html))
-* [RPM 4.16.1](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.tar.bz2) ([Release notes](wiki/Releases/4.16.1.html))
-* [RPM 4.16.0](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.0.tar.bz2) ([Release notes](wiki/Releases/4.16.0.html))
+* [RPM 4.16.1.3](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.3.tar.bz2) ([Release notes](wiki/Releases/4.16.1.3.html))
+* [RPM 4.16.1.2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.2.tar.bz2) ([Release notes](wiki/Releases/4.16.1.2.html))
+* [RPM 4.16.1](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.tar.bz2) ([Release notes](wiki/Releases/4.16.1.html))
+* [RPM 4.16.0](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.0.tar.bz2) ([Release notes](wiki/Releases/4.16.0.html))
 
 ### RPM 4.15.x
-* [RPM 4.15.1.1](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.1.tar.bz2) ([Release notes](wiki/Releases/4.15.1.1.html))
-* [RPM 4.15.1](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2) ([Release notes](wiki/Releases/4.15.1.html))
-* [RPM 4.15.0](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.0.tar.bz2) ([Release notes](wiki/Releases/4.15.0.html))
+* [RPM 4.15.1.1](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.1.1.tar.bz2) ([Release notes](wiki/Releases/4.15.1.1.html))
+* [RPM 4.15.1](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2) ([Release notes](wiki/Releases/4.15.1.html))
+* [RPM 4.15.0](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.0.tar.bz2) ([Release notes](wiki/Releases/4.15.0.html))
 
 ## Current test releases
 
@@ -26,4 +26,4 @@ For older releases, head over to [RPM timeline](timeline.html).
 
 ### POPT
 
-* [POPT 1.18](http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.18.tar.gz) ([Release notes](https://github.com/rpm-software-management/popt/releases/tag/popt-1.18-release))
+* [POPT 1.18](https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.18.tar.gz) ([Release notes](https://github.com/rpm-software-management/popt/releases/tag/popt-1.18-release))

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ capable of
 ## News
 #### RPM 4.17.0 ALPHA released! (Apr 26 2021)
 * See [draft release notes](wiki/Releases/4.17.0) for details and download information
-* [Original announcement](https://lists.rpm.org/pipermail/rpm-announce/2021-April/000088.html)
+* [Original announcement](http://lists.rpm.org/pipermail/rpm-announce/2021-April/000088.html)
 * Highlights include:
   * More robust install failure handling
   * Many macro improvements, in particular wrt Lua integration

--- a/max-rpm-snapshot/index.md
+++ b/max-rpm-snapshot/index.md
@@ -2,5 +2,5 @@
 layout: redirected
 sitemap: false
 permalink: /max-rpm-snapshot/
-redirect_to: http://ftp.rpm.org/max-rpm/
+redirect_to: https://ftp.osuosl.org/pub/rpm/max-rpm/
 ---

--- a/max-rpm/index.md
+++ b/max-rpm/index.md
@@ -2,5 +2,5 @@
 layout: redirected
 sitemap: false
 permalink: /max-rpm/
-redirect_to: http://ftp.rpm.org/max-rpm/
+redirect_to: https://ftp.osuosl.org/pub/rpm/max-rpm/
 ---

--- a/problems/summit2009.md
+++ b/problems/summit2009.md
@@ -59,6 +59,6 @@ Currently rpm only counts the number of packages with the same name when it calc
 Add a convenient way for scriptlet authors to find out which version of the package was installed before/obsoleted. Idea: put headerids in some ENV var, query with --querybynumber.
 
 ### Using tilde (~) in version
-Michael suggested to use the tilde (~) in version numbers. Versions 1.3~foo comes just before 1.3. This feature could be (mis)used as a version separator in kernel packages. That solves the problem that 2.6.31_8.1.3 is newer than 2.6.31.1_8.1.3 (whereas 2.6.31~8.1.3 is older than 2.6.31.1~8.1.3). There is already a ticket for that: [http://rpm.org/ticket/56](http://rpm.org/ticket/56)
+Michael suggested to use the tilde (~) in version numbers. Versions 1.3~foo comes just before 1.3. This feature could be (mis)used as a version separator in kernel packages. That solves the problem that 2.6.31_8.1.3 is newer than 2.6.31.1_8.1.3 (whereas 2.6.31~8.1.3 is older than 2.6.31.1~8.1.3). There is already a ticket for that: [https://rpm.org/ticket/56](https://rpm.org/ticket/56)
 
 Also see [https://bugzilla.novell.com/show_bug.cgi?id=540558](https://bugzilla.novell.com/show_bug.cgi?id=540558), [https://bugzilla.novell.com/show_bug.cgi?id=466994](https://bugzilla.novell.com/show_bug.cgi?id=466994) 

--- a/software.md
+++ b/software.md
@@ -29,7 +29,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [Copr](https://fedorahosted.org/copr/) is a lightweight build- and distribution system.
 * [Iurt](https://wiki.mageia.org/en/Iurt) is a package build system.
 * [Koji](https://fedorahosted.org/koji/) is a package build and tracking system.
-* [Mock](https://hosted.fedoraproject.org/projects/mock/) is a 'simple' chroot build environment manager for building RPMs.
+* [Mock](https://github.com/rpm-software-management/mock) is a 'simple' chroot build environment manager for building RPMs.
 * [Mach](http://thomas.apestaart.org/projects/mach/) is a more generic chroot environment manager that can also be used for building RPMs.
 * [Mezzanine](http://beta.kainx.org/wiki/view/Mezzanine) is a set of tools which simplify the management of software packages and collections of software packages. 
 

--- a/software.md
+++ b/software.md
@@ -31,7 +31,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [Koji](https://fedorahosted.org/koji/) is a package build and tracking system.
 * [Mock](https://github.com/rpm-software-management/mock) is a 'simple' chroot build environment manager for building RPMs.
 * [Mach](http://thomas.apestaart.org/projects/mach/) is a more generic chroot environment manager that can also be used for building RPMs.
-* [Mezzanine](http://beta.kainx.org/wiki/view/Mezzanine) is a set of tools which simplify the management of software packages and collections of software packages. 
+* [Mezzanine](https://warewulf.lbl.gov/mezzanine.html) is a set of tools which simplify the management of software packages and collections of software packages. 
 
 ### Other tools
 * [DeltaRPM](http://gitorious.org/deltarpm/) contais tools for creating and applying change deltas of RPM packages

--- a/software.md
+++ b/software.md
@@ -47,7 +47,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * Python bindings for RPM are distributed as part of [RPM releases](download).
 * [JRPM](http://jrpm.sourceforge.net/) is a java library to manipule and create RPM archives.
 * [Redline](http://www.introspectrum.com/oss/) is a pure Java library for manipulating RPM Package Manager packages.
-* [phprpm](http://cekirdek.uludag.org.tr/~meren/php_rpm/) provides some basic functionality for accessing RPM files from PHP programs.
+* [php-rpminfo](https://git.remirepo.net/cgit/tools/php-rpminfo.git/) allows to retrieve information from RPM files or from the installed RPMs database from PHP. See [docs](https://www.php.net/rpminfo) for details.
 * [perl-URPM](http://gitweb.mageia.org/software/rpm/perl-URPM/) is a Perl extension for manipulating rpm headers and packages.
 * [libsolv](https://github.com/openSUSE/libsolv) has bindings for Perl, Python and Ruby. 
 * [Rust RPM](https://github.com/rustrpm) has Rust bindings for RPM and associated tools.

--- a/software.md
+++ b/software.md
@@ -50,6 +50,6 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [php-rpminfo](https://git.remirepo.net/cgit/tools/php-rpminfo.git/) allows to retrieve information from RPM files or from the installed RPMs database from PHP. See [docs](https://www.php.net/rpminfo) for details.
 * [perl-URPM](http://gitweb.mageia.org/software/rpm/perl-URPM/) is a Perl extension for manipulating rpm headers and packages.
 * [libsolv](https://github.com/openSUSE/libsolv) has bindings for Perl, Python and Ruby. 
-* [Rust RPM](https://github.com/rustrpm) has Rust bindings for RPM and associated tools.
+* [librpm.rs](https://github.com/rpm-software-management/librpm.rs) has Rust bindings for librpm.
 
 

--- a/software.md
+++ b/software.md
@@ -23,7 +23,6 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [cpanspec](http://cpanspec.sourceforge.net/) is another tool for creating RPM packages from Perl CPAN modules.
 * [rpmrebuild](http://rpmrebuild.sourceforge.net/) is a tool that can generate a spec from an already installed RPM (useful when you don't have access to real source rpm, eg with packages of proprietary software)
 * [Specfile Editor](http://www.eclipse.org/linuxtools/projectPages/specfile/) is a spec file editor plugin for Eclipse.
-* [RPM Stubby](http://www.eclipse.org/linuxtools/projectPages/rpmstubby/) is a spec file generator plugin for Eclipse. 
 
 ### Build tools 
 * [Open Build Service](http://openbuildservice.org/) is a generic build- and distribution system.

--- a/software.md
+++ b/software.md
@@ -18,7 +18,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 
 ### Packager tools
 * [rpmlint](https://github.com/rpm-software-management/rpmlint) is a tool for checking for common errors in RPM packaging.
-* [rpmdevtools](https://hosted.fedoraproject.org/projects/rpmdevtools) contains scripts and (X)Emacs support files to aid in RPM packaging.
+* [rpmdevtools](https://fedoraproject.org/wiki/Rpmdevtools) contains scripts and (X)Emacs support files to aid in RPM packaging.
 * [cpan2rpm](http://search.cpan.org/~ecalder/cpan2rpm/) generates RPM packages from Perl CPAN modules.
 * [cpanspec](http://cpanspec.sourceforge.net/) is another tool for creating RPM packages from Perl CPAN modules.
 * [rpmrebuild](http://rpmrebuild.sourceforge.net/) is a tool that can generate a spec from an already installed RPM (useful when you don't have access to real source rpm, eg with packages of proprietary software)

--- a/software.md
+++ b/software.md
@@ -43,7 +43,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [perl-RPM2](http://search.cpan.org/dist/RPM2/) provides an object-oriented interface to RPM facilities for Perl.
 * [perl-RPM4](http://search.cpan.org/~tvignaud/RPM4/) provides an object-oriented interface to RPM facilities for Perl.
 * [RPM-Specfile](http://search.cpan.org/dist/RPM-Specfile/) is a Perl extension for creating RPM specfiles.
-* [Ruby-RPM](http://rubyforge.org/projects/ruby-rpm/) provides Ruby bindings to RPM.
+* [Ruby-RPM](https://github.com/hansode/ruby-2.1.x-rpm) provides Ruby bindings to RPM.
 * Python bindings for RPM are distributed as part of [RPM releases](download).
 * [JRPM](http://jrpm.sourceforge.net/) is a java library to manipule and create RPM archives.
 * [Redline](http://www.introspectrum.com/oss/) is a pure Java library for manipulating RPM Package Manager packages.

--- a/software.md
+++ b/software.md
@@ -43,7 +43,6 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [perl-RPM2](http://search.cpan.org/dist/RPM2/) provides an object-oriented interface to RPM facilities for Perl.
 * [perl-RPM4](http://search.cpan.org/~tvignaud/RPM4/) provides an object-oriented interface to RPM facilities for Perl.
 * [RPM-Specfile](http://search.cpan.org/dist/RPM-Specfile/) is a Perl extension for creating RPM specfiles.
-* [Ruby-RPM](https://github.com/hansode/ruby-2.1.x-rpm) provides Ruby bindings to RPM.
 * Python bindings for RPM are distributed as part of [RPM releases](download).
 * [JRPM](http://jrpm.sourceforge.net/) is a java library to manipule and create RPM archives.
 * [Redline](http://www.introspectrum.com/oss/) is a pure Java library for manipulating RPM Package Manager packages.

--- a/software.md
+++ b/software.md
@@ -34,7 +34,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [Mezzanine](https://warewulf.lbl.gov/mezzanine.html) is a set of tools which simplify the management of software packages and collections of software packages. 
 
 ### Other tools
-* [DeltaRPM](http://gitorious.org/deltarpm/) contais tools for creating and applying change deltas of RPM packages
+* [DeltaRPM](https://github.com/rpm-software-management/deltarpm) contais tools for creating and applying change deltas of RPM packages
 * [rpm2html](http://www.nongnu.org/rpm2html/) generates web pages that describe a set of RPM packages.
 * [rpmreaper](https://fedorahosted.org/rpmreaper/) is a ncurses-based application for finding unnecessary packages in the system.
 * [libsolv](https://github.com/openSUSE/libsolv) is library for package dependency resolution. 

--- a/software.md
+++ b/software.md
@@ -17,7 +17,7 @@ Here you can find links to software related to RPM such as frontends, packaging 
 * [Poldek](http://poldek.pld-linux.org/) is another frontend for RPM, primarily used by the PLD distribution. 
 
 ### Packager tools
-* [rpmlint](http://rpmlint.zarb.org/) is a tool for checking for common errors in RPM packaging.
+* [rpmlint](https://github.com/rpm-software-management/rpmlint) is a tool for checking for common errors in RPM packaging.
 * [rpmdevtools](https://hosted.fedoraproject.org/projects/rpmdevtools) contains scripts and (X)Emacs support files to aid in RPM packaging.
 * [cpan2rpm](http://search.cpan.org/~ecalder/cpan2rpm/) generates RPM packages from Perl CPAN modules.
 * [cpanspec](http://cpanspec.sourceforge.net/) is another tool for creating RPM packages from Perl CPAN modules.

--- a/timeline.md
+++ b/timeline.md
@@ -598,7 +598,7 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 4.4.2 released (Jul 21st 2005 ??) ####
 
- * [rpm-4.4.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.tar.gz)
+ * [rpm-4.4.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.4.x/rpm-4.4.2.tar.gz)
 
 #### RPM 4.4.1 released (??) ####
 

--- a/timeline.md
+++ b/timeline.md
@@ -567,7 +567,7 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
  * Dozens of bugfixes and minor improvements all around
  * [Summary of changes](wiki/Releases/4.4.2.3)
- * [Original announcement](https://lists.rpm.org/pipermail/rpm-announce/2008-April/000003.html) (with incorrect tarball url, duh)
+ * [Original announcement](http://lists.rpm.org/pipermail/rpm-announce/2008-April/000003.html) (with incorrect tarball url, duh)
 
 
 #### RPM development switches to GIT (Mar 31th 2008) ####
@@ -577,24 +577,24 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 #### RPM 4.4.2.3 release candidate 1 out for testing (Jan 25th 2008) ####
 
  * Dozens of bugfixes and minor improvements all around
- * [Original announcement](https://lists.rpm.org/pipermail/rpm-maint/2008-January/000737.html)
+ * [Original announcement](http://lists.rpm.org/pipermail/rpm-maint/2008-January/000737.html)
 
 #### RPM 4.4.2.2 released! (Oct 3rd 2007) ####
 
  * Dozens of bugfixes and minor improvements all around
  * [Summary of changes](wiki/Releases/4.4.2.2)
- * [Original announcement](https://lists.rpm.org/pipermail/rpm-maint/2007-October/000546.html)
+ * [Original announcement](http://lists.rpm.org/pipermail/rpm-maint/2007-October/000546.html)
 
 #### RPM 4.4.2.1 released! (Jul 23rd 2007) ####
 
  * Dozens of bugfixes and minor improvements all around
  * Cleaning up of vendor specific hacks etc
  * [Summary of changes](wiki/Releases/4.4.2.1)
- * [Original announcement](https://lists.rpm.org/pipermail/rpm-announce/2007-July/000001.html)
+ * [Original announcement](http://lists.rpm.org/pipermail/rpm-announce/2007-July/000001.html)
 
 #### rpm.org reboot (Dec 14th 2006) ####
 
- * [Original announcement](https://lists.rpm.org/pipermail/rpm-announce/2006-December/000005.html)
+ * [Original announcement](http://lists.rpm.org/pipermail/rpm-announce/2006-December/000005.html)
 
 #### RPM 4.4.2 released (Jul 21st 2005 ??) ####
 

--- a/timeline.md
+++ b/timeline.md
@@ -598,7 +598,7 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 4.4.2 released (Jul 21st 2005 ??) ####
 
- * [rpm-4.4.2.tar.gz](http://ftp.rpm.org/releases/rpm-4.4.x/rpm-4.4.2.tar.gz)
+ * [rpm-4.4.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.tar.gz)
 
 #### RPM 4.4.1 released (??) ####
 
@@ -610,7 +610,7 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 4.3.3 released (Nov 2 2005 ??) ####
 
- * [rpm-4.3.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.3.x/rpm-4.3.3.tar.gz)
+ * [rpm-4.3.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.3.x/rpm-4.3.3.tar.gz)
 
 #### RPM 4.2.3 released (Sep 2004 ??) ####
 
@@ -644,15 +644,15 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 4.1 released (Sep 17 2002 ??) ####
 
- * [rpm-4.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.1.x/rpm-4.1.tar.gz)
+ * [rpm-4.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.1.x/rpm-4.1.tar.gz)
 
 #### RPM 4.0.4 released (Mar 14 2002 ??) ####
 
- * [rpm-4.0.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.0.x/rpm-4.0.4.tar.gz)
+ * [rpm-4.0.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.0.x/rpm-4.0.4.tar.gz)
 
 #### RPM 4.0.3 released (Dec 3 2001 ??) ####
 
- * [rpm-4.0.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.0.x/rpm-4.0.3.tar.gz)
+ * [rpm-4.0.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.0.x/rpm-4.0.3.tar.gz)
 
 #### RPM specified as the LSB packaging format (Jun 29 2001) ####
  * [Linux Standard Base 1.0](http://refspecs.linuxfoundation.org/LSB_1.0.0/gLSB/book1.html) included RPM as the standard packaging format.
@@ -660,27 +660,27 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 4.0.2 released (Mar 13 2001 ??) ####
 
- * [rpm-4.0.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.0.x/rpm-4.0.2.tar.gz)
+ * [rpm-4.0.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.0.x/rpm-4.0.2.tar.gz)
 
 #### RPM 4.0.1 released (Jan 18 2001 ??) ####
 
- * [rpm-4.0.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.0.x/rpm-4.0.1.tar.gz)
+ * [rpm-4.0.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.0.x/rpm-4.0.1.tar.gz)
 
 #### RPM 4.0 released (Sep 13 2000 ??) ####
 
- * [rpm-4.0.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-4.0.x/rpm-4.0.tar.gz)
+ * [rpm-4.0.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.0.x/rpm-4.0.tar.gz)
 
 #### RPM 3.0.6 released (Sep 13 2000 ??) ####
 
- * [rpm-3.0.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.6.tar.gz)
+ * [rpm-3.0.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.6.tar.gz)
 
 #### RPM 3.0.5 released (Jul 20 2000 ??) ####
 
- * [rpm-3.0.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.5.tar.gz)
+ * [rpm-3.0.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.5.tar.gz)
 
 #### RPM 3.0.4 released (Mar 16 2000 ??) ####
 
- * [rpm-3.0.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.4.tar.gz)
+ * [rpm-3.0.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.4.tar.gz)
 
 #### RPM renamed (Jan 17 2000) ####
 
@@ -689,83 +689,83 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 3.0.3 released (Oct 6 1999 ??) ####
 
- * [rpm-3.0.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.3.tar.gz)
+ * [rpm-3.0.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.3.tar.gz)
 
 #### RPM 3.0.2 released (Jul 7 1999 ??) ####
 
- * [rpm-3.0.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.2.tar.gz)
+ * [rpm-3.0.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.2.tar.gz)
 
 #### RPM 3.0.1 released (May 24 1999 ??) ####
 
- * [rpm-3.0.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.1.tar.gz)
+ * [rpm-3.0.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.1.tar.gz)
 
 #### RPM 3.0 released (Apr 19 1999 ??) ####
 
- * [rpm-3.0.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-3.0.x/rpm-3.0.tar.gz)
+ * [rpm-3.0.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-3.0.x/rpm-3.0.tar.gz)
 
 #### RPM 2.5.6 released (Dec 29 1998 ??) ####
 
- * [rpm-2.5.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.6.tar.gz)
+ * [rpm-2.5.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.6.tar.gz)
 
 #### RPM 2.5.5 released (Oct 15 1998 ??) ####
 
- * [rpm-2.5.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.5.tar.gz)
+ * [rpm-2.5.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.5.tar.gz)
 
 #### RPM 2.5.4 released (Sep 30 1998 ??) ####
 
- * [rpm-2.5.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.4.tar.gz)
+ * [rpm-2.5.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.4.tar.gz)
 
 #### RPM 2.5.3 released (Sep 5 1998 ??) ####
 
- * [rpm-2.5.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.3.tar.gz)
+ * [rpm-2.5.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.3.tar.gz)
 
 #### RPM 2.5.2 released (Jul 1 1998 ??) ####
 
- * [rpm-2.5.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.2.tar.gz)
+ * [rpm-2.5.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.2.tar.gz)
 
 #### RPM 2.5.1 released (May 28 1998 ??) ####
 
- * [rpm-2.5.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.1.tar.gz)
+ * [rpm-2.5.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.1.tar.gz)
 
 #### RPM 2.5 released (May 15 1998 ??) ####
 
- * [rpm-2.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.5.x/rpm-2.5.tar.gz)
+ * [rpm-2.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.5.x/rpm-2.5.tar.gz)
 
 #### RPM 2.4.12 released (Jan 8 1998 ??) ####
 
- * [rpm-2.4.12.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.12.tar.gz)
+ * [rpm-2.4.12.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.12.tar.gz)
 
 #### RPM 2.4.11 released (Dec 30 1997 ??) ####
 
- * [rpm-2.4.11.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.11.tar.gz)
+ * [rpm-2.4.11.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.11.tar.gz)
 
 #### RPM 2.4.10 released (Oct 31 1997 ??) ####
 
- * [rpm-2.4.10.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.10.tar.gz)
+ * [rpm-2.4.10.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.10.tar.gz)
 
 #### RPM 2.4.9 released (Oct 28 1997 ??) ####
 
- * [rpm-2.4.9.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.9.tar.gz)
+ * [rpm-2.4.9.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.9.tar.gz)
 
 #### RPM 2.4.8 released (Oct 10 1997 ??) ####
 
- * [rpm-2.4.8.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.8.tar.gz)
+ * [rpm-2.4.8.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.8.tar.gz)
 
 #### RPM 2.4.7 released (Sep 12 1997 ??) ####
 
- * [rpm-2.4.7.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.7.tar.gz)
+ * [rpm-2.4.7.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.7.tar.gz)
 
 #### RPM 2.4.6 released (Aug 29 1997 ??) ####
 
- * [rpm-2.4.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.6.tar.gz)
+ * [rpm-2.4.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.6.tar.gz)
 
 #### RPM 2.4.5 released (Aug 26 1997 ??) ####
 
- * [rpm-2.4.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.5.tar.gz)
+ * [rpm-2.4.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.5.tar.gz)
 
 #### RPM 2.4.4 released (Aug 21 1997 ??) ####
 
- * [rpm-2.4.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.4.tar.gz)
+ * [rpm-2.4.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.4.tar.gz)
 
 #### License change to dual GPL/LGPL (Aug 10th 1997) ####
 
@@ -776,99 +776,99 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 2.4.3 released (Jul 16 1997 ??) ####
 
- * [rpm-2.4.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.3.tar.gz)
+ * [rpm-2.4.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.3.tar.gz)
 
 #### RPM 2.4.2 released (Jun 28 1997 ??) ####
 
- * [rpm-2.4.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.2.tar.gz)
+ * [rpm-2.4.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.2.tar.gz)
 
 #### RPM 2.4.1 released (May 27 1997 ??) ####
 
- * [rpm-2.4.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.1.tar.gz)
+ * [rpm-2.4.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.1.tar.gz)
 
 #### RPM 2.4 released (May 16 1997 ??) ####
 
- * [rpm-2.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.4.x/rpm-2.4.tar.gz)
+ * [rpm-2.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.4.x/rpm-2.4.tar.gz)
 
 #### RPM 2.3.11 released (Apr 24 1997 ??) ####
 
- * [rpm-2.3.11.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.11.tar.gz)
+ * [rpm-2.3.11.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.11.tar.gz)
 
 #### RPM 2.3.10 released (Apr 16 1997 ??) ####
 
- * [rpm-2.3.10.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.10.tar.gz)
+ * [rpm-2.3.10.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.10.tar.gz)
 
 #### RPM 2.3.9 released (Apr 8 1997 ??) ####
 
- * [rpm-2.3.9.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.9.tar.gz)
+ * [rpm-2.3.9.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.9.tar.gz)
 
 #### RPM 2.3.8 released (Mar 20 1997 ??) ####
 
- * [rpm-2.3.8.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.8.tar.gz)
+ * [rpm-2.3.8.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.8.tar.gz)
 
 #### RPM 2.3.7 released (Feb 20 1997 ??) ####
 
- * [rpm-2.3.7.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.7.tar.gz)
+ * [rpm-2.3.7.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.7.tar.gz)
 
 #### RPM 2.3.6 released (Feb 17 1997 ??) ####
 
- * [rpm-2.3.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.6.tar.gz)
+ * [rpm-2.3.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.6.tar.gz)
 
 #### RPM 2.3.5 released (Feb 14 1997 ??) ####
 
- * [rpm-2.3.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.5.tar.gz)
+ * [rpm-2.3.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.5.tar.gz)
 
 #### RPM 2.3.4 released (Jan 31 1997 ??) ####
 
- * [rpm-2.3.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.4.tar.gz)
+ * [rpm-2.3.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.4.tar.gz)
 
 #### RPM 2.3.3 released (Jan 24 1997 ??) ####
 
- * [rpm-2.3.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.3.tar.gz)
+ * [rpm-2.3.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.3.tar.gz)
 
 #### RPM 2.3.2 released (Jan 16 1997 ??) ####
 
- * [rpm-2.3.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.2.tar.gz)
+ * [rpm-2.3.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.2.tar.gz)
 
 #### RPM 2.3.1 released (Jan 15 1997 ??) ####
 
- * [rpm-2.3.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.1.tar.gz)
+ * [rpm-2.3.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.1.tar.gz)
 
 #### RPM 2.3 released (Dec 26 1996 ??) ####
 
- * [rpm-2.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.3.x/rpm-2.3.tar.gz)
+ * [rpm-2.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.3.x/rpm-2.3.tar.gz)
 
 #### RPM 2.2.11 released (Dec 20 1996 ??) ####
 
- * [rpm-2.2.11.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.11.tar.gz)
+ * [rpm-2.2.11.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.11.tar.gz)
 
 #### RPM 2.2.10 released (Dec 12 1996 ??) ####
 
- * [rpm-2.2.10.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.10.tar.gz)
+ * [rpm-2.2.10.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.10.tar.gz)
 
 #### RPM 2.2.9 released (Nov 22 1996 ??) ####
 
- * [rpm-2.2.9.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.9.tar.gz)
+ * [rpm-2.2.9.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.9.tar.gz)
 
 #### RPM 2.2.8 released (Oct 31 1996 ??) ####
 
- * [rpm-2.2.8.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.8.tar.gz)
+ * [rpm-2.2.8.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.8.tar.gz)
 
 #### RPM 2.2.7 released (Oct 17 1996 ??) ####
 
- * [rpm-2.2.7.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.7.tar.gz)
+ * [rpm-2.2.7.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.7.tar.gz)
 
 #### RPM 2.2.6 released (Sep 20 1996 ??) ####
 
- * [rpm-2.2.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.6.tar.gz)
+ * [rpm-2.2.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.6.tar.gz)
 
 #### RPM 2.2.5 released (Sep 02 1996 ??) ####
 
- * [rpm-2.2.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.5.tar.gz)
+ * [rpm-2.2.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.5.tar.gz)
 
 #### RPM 2.2.4 released (Aug 20 1996 ??) ####
 
- * [rpm-2.2.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.4.tar.gz)
+ * [rpm-2.2.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.4.tar.gz)
 
 #### RPM 2.2.3 released (Aug 08 1996 ??) ####
 
@@ -876,119 +876,119 @@ Due to a big surge in spam tickets in recent times, ticket creation and modifica
 
 #### RPM 2.2.2 released (Jul 23 1996 ??) ####
 
- * [rpm-2.2.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.2.tar.gz)
+ * [rpm-2.2.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.2.tar.gz)
 
 #### RPM 2.2.1 released (Jul 17 1996 ??) ####
 
- * [rpm-2.2.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.1.tar.gz)
+ * [rpm-2.2.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.1.tar.gz)
 
 #### RPM 2.2 released (Jul 16 1996 ??) ####
 
- * [rpm-2.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.2.x/rpm-2.2.tar.gz)
+ * [rpm-2.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.2.x/rpm-2.2.tar.gz)
 
 #### RPM 2.1.2 released (Jul 12 1996 ??) ####
 
- * [rpm-2.1.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.1.x/rpm-2.1.2.tar.gz)
+ * [rpm-2.1.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.1.x/rpm-2.1.2.tar.gz)
 
 #### RPM 2.1.1 released (Jul 11 1996 ??) ####
 
- * [rpm-2.1.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.1.x/rpm-2.1.1.tar.gz)
+ * [rpm-2.1.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.1.x/rpm-2.1.1.tar.gz)
 
 #### RPM 2.1 released (Jul 10 1996 ??) ####
 
- * [rpm-2.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.1.x/rpm-2.1.tar.gz)
+ * [rpm-2.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.1.x/rpm-2.1.tar.gz)
 
 #### RPM 2.0.11 released (Jun 05 1996 ??) ####
 
- * [rpm-2.0.11.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.11.tar.gz)
+ * [rpm-2.0.11.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.11.tar.gz)
 
 #### RPM 2.0.10 released (Jun 04 1996 ??) ####
 
- * [rpm-2.0.10.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.10.tar.gz)
+ * [rpm-2.0.10.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.10.tar.gz)
 
 #### RPM 2.0.9 released (May 23 1996 ??) ####
 
- * [rpm-2.0.9.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.9.tar.gz)
+ * [rpm-2.0.9.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.9.tar.gz)
 
 #### RPM 2.0.8 released (May 07 1996 ??) ####
 
- * [rpm-2.0.8.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.8.tar.gz)
+ * [rpm-2.0.8.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.8.tar.gz)
 
 #### RPM 2.0.7 released (April 15 1996 ??) ####
 
- * [rpm-2.0.7.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.7.tar.gz)
+ * [rpm-2.0.7.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.7.tar.gz)
 
 #### RPM 2.0.6 released (April 08 1996 ??) ####
 
- * [rpm-2.0.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.6.tar.gz)
+ * [rpm-2.0.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.6.tar.gz)
 
 #### RPM 2.0.5 released (April 03 1996 ??) ####
 
- * [rpm-2.0.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.5.tar.gz)
+ * [rpm-2.0.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.5.tar.gz)
 
 #### RPM 2.0.4 released (??) ####
 
- * [rpm-2.0.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.4.tar.gz)
+ * [rpm-2.0.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.4.tar.gz)
 
 #### RPM 2.0.3 released (??) ####
 
- * [rpm-2.0.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.3.tar.gz)
+ * [rpm-2.0.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.3.tar.gz)
 
 #### RPM 2.0.2 released (??) ####
 
- * [rpm-2.0.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.2.tar.gz)
+ * [rpm-2.0.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.2.tar.gz)
 
 #### RPM 2.0.1 released (??) ####
 
- * [rpm-2.0.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.1.tar.gz)
+ * [rpm-2.0.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.1.tar.gz)
 
 #### RPM 2.0 released (??) ####
 
- * [rpm-2.0.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-2.0.x/rpm-2.0.tar.gz)
+ * [rpm-2.0.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-2.0.x/rpm-2.0.tar.gz)
 
 #### RPM 1.4.7 released (??) ####
 
- * [rpm-1.4.7.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.7.tar.gz)
+ * [rpm-1.4.7.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.7.tar.gz)
 
 #### RPM 1.4.6 released (??) ####
 
- * [rpm-1.4.6.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.6.tar.gz)
+ * [rpm-1.4.6.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.6.tar.gz)
 
 #### RPM 1.4.5 released (??) ####
 
- * [rpm-1.4.5.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.5.tar.gz)
+ * [rpm-1.4.5.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.5.tar.gz)
 
 #### RPM 1.4.4 released (??) ####
 
- * [rpm-1.4.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.4.tar.gz)
+ * [rpm-1.4.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.4.tar.gz)
 
 #### RPM 1.4.2a released (??) ####
 
- * [rpm-1.4.2a.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.2a.tar.gz)
+ * [rpm-1.4.2a.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.2a.tar.gz)
 
 #### RPM 1.4.2 released (??) ####
 
- * [rpm-1.4.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.2.tar.gz)
+ * [rpm-1.4.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.2.tar.gz)
 
 #### RPM 1.4.1 released (??) ####
 
- * [rpm-1.4.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.1.tar.gz)
+ * [rpm-1.4.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.1.tar.gz)
 
 #### RPM 1.4 released (??) ####
 
- * [rpm-1.4.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.4.tar.gz)
+ * [rpm-1.4.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.4.tar.gz)
 
 #### RPM 1.3.1 released (??) ####
 
- * [rpm-1.3.1.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.3.1.tar.gz)
+ * [rpm-1.3.1.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.3.1.tar.gz)
 
 #### RPM 1.3 released (??) ####
 
- * [rpm-1.3.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.3.tar.gz)
+ * [rpm-1.3.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.3.tar.gz)
 
 #### RPM 1.2 released (??) ####
 
- * [rpm-1.2.tar.gz download](http://ftp.rpm.org/releases/historical/rpm-1.x/rpm-1.2.tar.gz)
+ * [rpm-1.2.tar.gz download](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-1.x/rpm-1.2.tar.gz)
 
 #### First commit (Nov 27th 1995) ####
 

--- a/user_doc/conditional_builds.md
+++ b/user_doc/conditional_builds.md
@@ -65,5 +65,5 @@ To pass options to configure or other scripts that understand a `--with-foo` or
 ```
 
 ## References
-* [doc/manual/conditionalbuilds](https://github.com/rpm-software-management/rpm/blob/master/doc/manual/conditionalbuilds)
+* [doc/manual/conditionalbuilds](https://github.com/rpm-software-management/rpm/blob/master/doc/manual/conditionalbuilds.md)
 * [macros](https://github.com/rpm-software-management/rpm/blob/master/macros.in)

--- a/user_doc/faq.md
+++ b/user_doc/faq.md
@@ -64,7 +64,7 @@ Or-dependencies are not supported in existing RPM versions. This can be
 achieved by having a common virtual provide in A and B, and having C require
 that.
 
-Since rpm version 4.13 you can also use [Boolean Dependencies](user_doc/boolean_dependencies.html). So you can directly use:
+Since rpm version 4.13 you can also use [Boolean Dependencies](boolean_dependencies.md). So you can directly use:
 
 ```
 Requires: ( pkgA >= 1.2.3 or pkgB )

--- a/wiki/Releases/4.10.0.md
+++ b/wiki/Releases/4.10.0.md
@@ -15,7 +15,7 @@ title: rpm.org - Releases
 ## Summary of changes from RPM 4.9.x
 
 ### General bugfixes and enhancements
- * Support dpkg-style sorting of tilde (~) in version/release (ticket [#56](http://rpm.org/ticket/56), [RhBug:734802](https://bugzilla.redhat.com/show_bug.cgi?id=734802), ...)
+ * Support dpkg-style sorting of tilde (~) in version/release (ticket [#56](https://rpm.org/ticket/56), [RhBug:734802](https://bugzilla.redhat.com/show_bug.cgi?id=734802), ...)
  * Automatically reload SELinux labels if policy changes while in transaction ([RhBug:746073](https://bugzilla.redhat.com/show_bug.cgi?id=746073))
  * Various error messages now include file name (or other information)
    on the failing file where previously unavailable
@@ -44,7 +44,7 @@ title: rpm.org - Releases
  * Detect file conflicts when permissions (user, group, mode) differ
 
 #### Queries
- * Recognize epoch as part of a label on queries etc (ticket [#117](http://rpm.org/ticket/117))
+ * Recognize epoch as part of a label on queries etc (ticket [#117](https://rpm.org/ticket/117))
  * Fix false match on trailing dash on queries etc ([RhBug:488567](https://bugzilla.redhat.com/show_bug.cgi?id=488567))
  * Include package architecture in --last output ([RhBug:768516](https://bugzilla.redhat.com/show_bug.cgi?id=768516))
  * Fix trailing whitespace on versionless dependencies in
@@ -55,7 +55,7 @@ title: rpm.org - Releases
  * Query string field formatting is now applied to all output, eg
    "error" messages like "(none)" which were previously unformatted
  * Show %verifyscript in --scripts query too
- * Show all interpreter arguments in --scripts query (ticket [#847](http://rpm.org/ticket/847))
+ * Show all interpreter arguments in --scripts query (ticket [#847](https://rpm.org/ticket/847))
  * Reflect --pipe command failures in exit code ([RhBug:735481](https://bugzilla.redhat.com/show_bug.cgi?id=735481))
 
 #### Keys and signatures
@@ -86,7 +86,7 @@ title: rpm.org - Releases
  * Add support for 7zip compressed sources
  * Fix package generation in presence of high inode numbers ([RhBug:714678](https://bugzilla.redhat.com/show_bug.cgi?id=714678))
  * Order hardlinks in a deltarpm friendlier way
- * %configure macro now defaults to --disable-dependency-tracking (ticket [#52](http://rpm.org/ticket/52))
+ * %configure macro now defaults to --disable-dependency-tracking (ticket [#52](https://rpm.org/ticket/52))
  * Support new GNOME/xdg help location in %find_lang ([RhBug:736523](https://bugzilla.redhat.com/show_bug.cgi?id=736523), others)
  * Fix various scripts to permit whitespace in $RPM_BUILD_ROOT path
 
@@ -251,7 +251,7 @@ title: rpm.org - Releases
    %{_vendor} macro default value.
  * Create and install platform configuration for all known architectures,
    on all OS'es
- * Do not attempt running the test-suite without fakechroot (ticket [#851](http://rpm.org/ticket/851))
+ * Do not attempt running the test-suite without fakechroot (ticket [#851](https://rpm.org/ticket/851))
  * Do not require support for XZ compression in the test-suite
  * Fix build with newer Berkeley DB versions when not using --with-external-db
  * Support for ancient bzip2 library versions removed

--- a/wiki/Releases/4.10.0.md
+++ b/wiki/Releases/4.10.0.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.10.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.10.x/rpm-4.10.0.tar.bz2) source
+ * [rpm-4.10.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.0.tar.bz2) source
  * SHA1SUM: d78f19194066c3895f91f58dc84e3aad69f0b02c
 
 ## Summary of changes from RPM 4.9.x

--- a/wiki/Releases/4.10.0.md
+++ b/wiki/Releases/4.10.0.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.10.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.0.tar.bz2) source
+ * [rpm-4.10.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.10.x/rpm-4.10.0.tar.bz2) source
  * SHA1SUM: d78f19194066c3895f91f58dc84e3aad69f0b02c
 
 ## Summary of changes from RPM 4.9.x

--- a/wiki/Releases/4.10.1.md
+++ b/wiki/Releases/4.10.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.1.tar.bz2) source
+ * [rpm-4.10.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.10.x/rpm-4.10.1.tar.bz2) source
  * SHA1SUM: 3881f0f0fb686405517bfa367c49d36a0cc7a2c3
 
 ## Summary of changes from RPM 4.10.0

--- a/wiki/Releases/4.10.1.md
+++ b/wiki/Releases/4.10.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.10.x/rpm-4.10.1.tar.bz2) source
+ * [rpm-4.10.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.1.tar.bz2) source
  * SHA1SUM: 3881f0f0fb686405517bfa367c49d36a0cc7a2c3
 
 ## Summary of changes from RPM 4.10.0

--- a/wiki/Releases/4.10.2.md
+++ b/wiki/Releases/4.10.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.10.x/rpm-4.10.2.tar.bz2) source
+ * [rpm-4.10.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.2.tar.bz2) source
  * SHA1SUM: 2455aa402823b34cdc3ee04e85accdffb70c5cb3
 
 ## Summary of changes from RPM 4.10.1

--- a/wiki/Releases/4.10.2.md
+++ b/wiki/Releases/4.10.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.2.tar.bz2) source
+ * [rpm-4.10.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.10.x/rpm-4.10.2.tar.bz2) source
  * SHA1SUM: 2455aa402823b34cdc3ee04e85accdffb70c5cb3
 
 ## Summary of changes from RPM 4.10.1

--- a/wiki/Releases/4.10.3.1.md
+++ b/wiki/Releases/4.10.3.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.3.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.3.1.tar.bz2) source
+ * [rpm-4.10.3.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.10.x/rpm-4.10.3.1.tar.bz2) source
  * SHA1SUM: b336cb1c28b43c061d2a0ce04decf3f013131a8b
 
 ## Summary of changes from RPM 4.10.3

--- a/wiki/Releases/4.10.3.1.md
+++ b/wiki/Releases/4.10.3.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.10.3.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.10.x/rpm-4.10.3.1.tar.bz2) source
+ * [rpm-4.10.3.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.10.x/rpm-4.10.3.1.tar.bz2) source
  * SHA1SUM: b336cb1c28b43c061d2a0ce04decf3f013131a8b
 
 ## Summary of changes from RPM 4.10.3

--- a/wiki/Releases/4.10.3.md
+++ b/wiki/Releases/4.10.3.md
@@ -19,7 +19,7 @@ title: rpm.org - Releases
 
 ### Package building
  * Make double-quoting work for special %doc for consistency with
-   rest of %files section (ticket [#858](http://rpm.org/ticket/858))
+   rest of %files section (ticket [#858](https://rpm.org/ticket/858))
  * Fix rpmspec --parse to not require sources and patches to be present
  * Report the actual unknown option instead of ? in parametrized macros
 

--- a/wiki/Releases/4.11.0.1.md
+++ b/wiki/Releases/4.11.0.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.11.0.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.11.x/rpm-4.11.0.1.tar.bz2) source
+ * [rpm-4.11.0.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.11.x/rpm-4.11.0.1.tar.bz2) source
  * SHA1SUM: 4f4362c40136c3a59ce164c142d62ea081793379
 
 ## Summary of changes from RPM 4.11.0

--- a/wiki/Releases/4.11.0.md
+++ b/wiki/Releases/4.11.0.md
@@ -30,7 +30,7 @@ title: rpm.org - Releases
  * Fix backup of shared %config files causing overwriting the backed up
    content with new package contents (ie destroying the backed up data)
  * Fix locale dependent behavior in rpm2cpio.sh ([RhBug:878363](https://bugzilla.redhat.com/show_bug.cgi?id=878363))
- * Fix disk-space accounting wrt intermediate space requirement during transaction (ticket [#175](http://rpm.org/ticket/175), [RhBug:872314](https://bugzilla.redhat.com/show_bug.cgi?id=872314))
+ * Fix disk-space accounting wrt intermediate space requirement during transaction (ticket [#175](https://rpm.org/ticket/175), [RhBug:872314](https://bugzilla.redhat.com/show_bug.cgi?id=872314))
  * Fix disk-space accounting wrt inodes
 
  * New --undefine cli switch for undefining macros (related to [RhBug:876308](https://bugzilla.redhat.com/show_bug.cgi?id=876308))
@@ -55,7 +55,7 @@ title: rpm.org - Releases
    stages of build
  * New [%autosetup](/user_doc/autosetup.html) (and %autopatch) macros for fully automating
    unpackaging of sources and application of patches, either with plain
-   'patch' or a number of DVCS systems (git, hg, bzr, quilt...) (ticket [#54](http://rpm.org/ticket/54))
+   'patch' or a number of DVCS systems (git, hg, bzr, quilt...) (ticket [#54](https://rpm.org/ticket/54))
  * New built-in %dirname macro
 
  * Fix rpmspec --parse to not require sources and patches to be present
@@ -72,9 +72,9 @@ title: rpm.org - Releases
  * Fix bogus "unclosed %if" error when %include is used in spec conditionals
  * Fix %license as a %files list virtual attribute
  * New "special" %license with non-absolute path (similar to %doc) to
-   allow easily separating licenses from normal documentation (ticket [#116](http://rpm.org/ticket/116))
+   allow easily separating licenses from normal documentation (ticket [#116](https://rpm.org/ticket/116))
  * Make double-quoting work for special %doc and %license for consistency
-   with rest of %files section (ticket [#858](http://rpm.org/ticket/858))
+   with rest of %files section (ticket [#858](https://rpm.org/ticket/858))
  * Accept "owner" as an alias to "user" %verify attribute ([RhBug:838657](https://bugzilla.redhat.com/show_bug.cgi?id=838657))
  * Warn about invalid %changelog dates (eg wrong day name) ([RhBug:843525](https://bugzilla.redhat.com/show_bug.cgi?id=843525))
  * PrePreq tag no longer accepts extra qualifiers (such as "post")

--- a/wiki/Releases/4.11.1.md
+++ b/wiki/Releases/4.11.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.11.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.11.x/rpm-4.11.1.tar.bz2) source
+ * [rpm-4.11.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.11.x/rpm-4.11.1.tar.bz2) source
  * SHA1SUM: `31ddc4185137ce3f718c99e91dcb040614fe820c`
 
 ## Summary of changes from RPM 4.11.0.1

--- a/wiki/Releases/4.11.2.md
+++ b/wiki/Releases/4.11.2.md
@@ -26,7 +26,7 @@ title: rpm.org - Releases
  * Fix scriptlets in relocatable packages not always executing with $RPM_INSTALL_PREFIX* defined ([RhBug:979443](https://bugzilla.redhat.com/show_bug.cgi?id=979443))
  * Fix RPMTAG_NOSOURCE and RPMTAG_NOPATCH tags defined as non-arrays ([RhBug:991329](https://bugzilla.redhat.com/show_bug.cgi?id=991329))
  * Fix a possible loophole in file triplet sanity-checking
- * Fix name service initialization where passwd and group service differs from host (ticket [#157](http://rpm.org/ticket/157))
+ * Fix name service initialization where passwd and group service differs from host (ticket [#157](https://rpm.org/ticket/157))
  * Add support for ppc64le architecture
 
 ### Package building

--- a/wiki/Releases/4.11.2.md
+++ b/wiki/Releases/4.11.2.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.11.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.11.x/rpm-4.11.2.tar.bz2) source
+ * [rpm-4.11.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.11.x/rpm-4.11.2.tar.bz2) source
  * SHA1SUM: `ceef44bd180d48d4004c437bc31a3ea038f54e3e`
 
 ## Summary of changes from RPM 4.11.1

--- a/wiki/Releases/4.11.3.md
+++ b/wiki/Releases/4.11.3.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.11.3.tar.bz2](http://ftp.rpm.org/releases/rpm-4.11.x/rpm-4.11.3.tar.bz2) source
+ * [rpm-4.11.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.11.x/rpm-4.11.3.tar.bz2) source
  * SHA1SUM: `ae9ff06718e877d897ed47e3795b0e56727d752c`
 
 ## Summary of changes from RPM 4.11.2

--- a/wiki/Releases/4.11.3.md
+++ b/wiki/Releases/4.11.3.md
@@ -17,7 +17,7 @@ title: rpm.org - Releases
 ### General bugfixes and enhancements
 
  * Fix double-free on malformed signature header ([RhBug:1133885](https://bugzilla.redhat.com/show_bug.cgi?id=1133885))
- * Fix verification wrt duplicate user/groupnames (ticket [#872](http://rpm.org/ticket/872))
+ * Fix verification wrt duplicate user/groupnames (ticket [#872](https://rpm.org/ticket/872))
  * Fix mixed binary + source rpm installation progress ([RhBug:984724](https://bugzilla.redhat.com/show_bug.cgi?id=984724))
  * Fix curl globbing being enabled on remote retrieval ([RhBug:1076277](https://bugzilla.redhat.com/show_bug.cgi?id=1076277))
  * Fix verification of SHA224 signatures ([RhBug:1066494](https://bugzilla.redhat.com/show_bug.cgi?id=1066494))

--- a/wiki/Releases/4.12.0.1.md
+++ b/wiki/Releases/4.12.0.1.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.12.0.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.12.x/rpm-4.12.0.1.tar.bz2) source
+ * [rpm-4.12.0.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.12.x/rpm-4.12.0.1.tar.bz2) source
  * SHA1SUM: `d416bdb249b246b00b2d5d34c66e7f5a68a62524`
 
 ## Summary of changes from RPM 4.12.0

--- a/wiki/Releases/4.12.0.2.md
+++ b/wiki/Releases/4.12.0.2.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.12.0.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.12.x/rpm-4.12.0.2.tar.bz2) source
+ * [rpm-4.12.0.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.12.x/rpm-4.12.0.2.tar.bz2) source
  * SHA1SUM: f32216a3bb342fff7a0e3c7d9fa452b7eaae19da
 
 ## Summary of changes from RPM 4.12.0.1

--- a/wiki/Releases/4.12.0.md
+++ b/wiki/Releases/4.12.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.12.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.12.x/rpm-4.12.0.tar.bz2) source
+ * [rpm-4.12.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.12.x/rpm-4.12.0.tar.bz2) source
  * SHA1SUM: `9e91dd0cdd8178aafdb165a7c9ae3a60ce8f6007`
 
 ## Summary of changes from RPM 4.11.2

--- a/wiki/Releases/4.12.0.md
+++ b/wiki/Releases/4.12.0.md
@@ -22,7 +22,7 @@ title: rpm.org - Releases
  * New --recommends, --suggests, --supplements and --enhances query aliases
    for querying weak dependencies
  * New optional payload format to support large (> 4GB) files within
-   packages (ticket [#41](http://rpm.org/ticket/41))
+   packages (ticket [#41](https://rpm.org/ticket/41))
  * New rpm2archive utility for converting rpm payload to tar archives
 
  * Fix curl globbing being enabled on remote retrieval ([RhBug:1076277](https://bugzilla.redhat.com/show_bug.cgi?id=1076277))
@@ -31,7 +31,7 @@ title: rpm.org - Releases
  * Fix mixed binary + source rpm installation progress ([RhBug:984724](https://bugzilla.redhat.com/show_bug.cgi?id=984724))
  * Fix file actions sometimes carrying state across multiple rpmtsRun()
    calls ([RhBug:1076552](https://bugzilla.redhat.com/show_bug.cgi?id=1076552))
- * Fix duplicate usernames causing false positives on verification (ticket [#872](http://rpm.org/ticket/872))
+ * Fix duplicate usernames causing false positives on verification (ticket [#872](https://rpm.org/ticket/872))
  * Fix ordering to prefer self-provides on ordering when appropriate ([RhBug:1111349](https://bugzilla.redhat.com/show_bug.cgi?id=1111349))
  * Fix a double-free on unpadded signature header
 
@@ -56,7 +56,7 @@ title: rpm.org - Releases
  * New %_smp_ncpus_max macro to configure CPU limit for parallel builds
    (related to [RhBug:669638](https://bugzilla.redhat.com/show_bug.cgi?id=669638))
  * New %make_build macro for hiding parallel-build magic from specs
-   (ticket [#115](http://rpm.org/ticket/115))
+   (ticket [#115](https://rpm.org/ticket/115))
  * New %_rundir macro for referring to /run (formerly /var/run) directory
  * New %__gpg_reserved_space macro allows preallocating space for signatures
    which allows very fast package signing
@@ -68,7 +68,7 @@ title: rpm.org - Releases
 
  * Fix ELF soname dependencies getting generated for non-library DSO's
    too (RhBug:???)
- * Fix garbage sonames sometimes getting added as dependencies (ticket [#158](http://rpm.org/ticket/158))
+ * Fix garbage sonames sometimes getting added as dependencies (ticket [#158](https://rpm.org/ticket/158))
  * Fix various issues in dependency generator
  * Fix libtool dependency generation with libtool >= 2.4.2 version
  * Fix external dependency generator to use the same generators as

--- a/wiki/Releases/4.13.0.1.md
+++ b/wiki/Releases/4.13.0.1.md
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.13.0.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.0.1.tar.bz2) source
+ * [rpm-4.13.0.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.13.x/rpm-4.13.0.1.tar.bz2) source
  * SHA1SUM: 9566f95f38fcb214e439c552f378c2f64ba0aff9
 
 ## Summary of changes from RPM 4.13.0

--- a/wiki/Releases/4.13.0.2.md
+++ b/wiki/Releases/4.13.0.2.md
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.13.0.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.0.2.tar.bz2) source
+ * [rpm-4.13.0.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.13.x/rpm-4.13.0.2.tar.bz2) source
  * SHA256SUM: 2f3e2c07c354d16f2305ddd93ed030c8403d59b272f2fb6722445b091ff14194
 
 ## Summary of changes from RPM 4.13.0.1

--- a/wiki/Releases/4.13.0.md
+++ b/wiki/Releases/4.13.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.13.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.0.tar.bz2) source
+ * [rpm-4.13.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.13.x/rpm-4.13.0.tar.bz2) source
  * SHA1SUM: c6ce4f879ca6a75340921093105e5ef9d33381d3
 
 ## Summary of changes from RPM 4.12.0.1

--- a/wiki/Releases/4.13.1.md
+++ b/wiki/Releases/4.13.1.md
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.13.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.13.x/rpm-4.13.1.tar.bz2) source
+ * [rpm-4.13.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.13.x/rpm-4.13.1.tar.bz2) source
  * SHA256SUM: 81e5bc8e46baa0710a19c7d9bb34c24baceefeeafd86a9033e1e4d9613bb5b60
 
 ## Summary of changes from RPM 4.13.0.2

--- a/wiki/Releases/4.14.0.md
+++ b/wiki/Releases/4.14.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.14.0.tar.bz2](http://ftp.rpm.org/releases/4.14.x/rpm-4.14.0.tar.bz2)
+ * [rpm-4.14.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/4.14.x/rpm-4.14.0.tar.bz2)
  * SHA256SUM: `06a0ad54600d3c42e42e02701697a8857dc4b639f6476edefffa714d9f496314`
 
 ## Summary of changes from RPM 4.13.x

--- a/wiki/Releases/4.14.1.md
+++ b/wiki/Releases/4.14.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.14.1 Release Notes
 
 ## Download information
- * [rpm-4.14.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.1.tar.bz2)
+ * [rpm-4.14.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.14.x/rpm-4.14.1.tar.bz2)
  * SHA256SUM: `43f40e2ccc3ca65bd3238f8c9f8399d4957be0878c2e83cba2746d2d0d96793b`
 
 ## Summary of changes from RPM 4.14.0

--- a/wiki/Releases/4.14.2.1.md
+++ b/wiki/Releases/4.14.2.1.md
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 ## Download information
 
- * [rpm-4.14.2.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.2.1.tar.bz2) source
+ * [rpm-4.14.2.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.14.x/rpm-4.14.2.1.tar.bz2) source
  * SHA256SUM: 1139c24b7372f89c0a697096bf9809be70ba55e006c23ff47305c1849d98acda
 
 ## Summary of changes from RPM 4.14.2

--- a/wiki/Releases/4.14.2.md
+++ b/wiki/Releases/4.14.2.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.14.2 Release Notes
 
 ## Download information
- * [rpm-4.14.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.2.tar.bz2)
+ * [rpm-4.14.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.14.x/rpm-4.14.2.tar.bz2)
  * SHA256SUM: `80cbc2c1e8e24e67c6f88b41d8ab5633b653a9a79d50d4750474a18cdb69352b`
 
 ## Summary of changes from RPM 4.14.1

--- a/wiki/Releases/4.14.3.md
+++ b/wiki/Releases/4.14.3.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.14.3 Release Notes
 
 ## Download information
- * [rpm-4.14.3.tar.bz2](http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2)
+ * [rpm-4.14.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.14.x/rpm-4.14.3.tar.bz2)
  * SHA256SUM: `13711268181a6e201eb9d4eb06384a7fcc42dcc6c9057a62c53472cfc5ba44b5`
 
 ## Summary of changes from RPM 4.14.2.1

--- a/wiki/Releases/4.15.0.md
+++ b/wiki/Releases/4.15.0.md
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.15.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.0.tar.bz2)
+ * [rpm-4.15.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.0.tar.bz2)
  * SHA256SUM: ``1e06723b13591e57c99ebe2006fb8daddc4cf72efb366a64a34673ba5f61c201``
 
 ## Summary of changes from RPM 4.14.x

--- a/wiki/Releases/4.15.1.1.md
+++ b/wiki/Releases/4.15.1.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.15.1.1 Release Notes
 
 ## Download information
- * Source: [rpm-4.15.1.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.1.tar.bz2)
+ * Source: [rpm-4.15.1.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.1.1.tar.bz2)
  * SHA256SUM: 346a2c33a1261918bee84dccc262d3a84a378da8400ff97c118a4a2861fc3b2b
 
 ## Summary of changes from RPM 4.15.1

--- a/wiki/Releases/4.15.1.md
+++ b/wiki/Releases/4.15.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.15.1 Release Notes
 
 ## Download information
- * [rpm-4.15.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2)
+ * [rpm-4.15.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.15.x/rpm-4.15.1.tar.bz2)
  * SHA256SUM: `ddef45f9601cd12042edfc9b6e37efcca32814e1e0f4bb8682d08144a3e2d230`
 
 ## Summary of changes from RPM 4.15.1

--- a/wiki/Releases/4.16.0.md
+++ b/wiki/Releases/4.16.0.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.16.0 Release Notes
 
 ## Download information
- * Source: [rpm-4.16.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.0.tar.bz2)
+ * Source: [rpm-4.16.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.0.tar.bz2)
  * SHA256SUM: ca5974e9da2939afb422598818ef187385061889ba766166c4a3829c5ef8d411
 
 ## Summary of changes from RPM 4.15.x

--- a/wiki/Releases/4.16.1.2.md
+++ b/wiki/Releases/4.16.1.2.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.16.1.2 Release Notes
 
 ## Download information
- * Source: [rpm-4.16.1.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.2.tar.bz2)
+ * Source: [rpm-4.16.1.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.2.tar.bz2)
  * SHA256SUM: 8357329ceefc92c41687988b22198b26f74a12a9a68ac00728f934a5c4b4cacc
 
 ## Summary of changes from RPM 4.16.1

--- a/wiki/Releases/4.16.1.3.md
+++ b/wiki/Releases/4.16.1.3.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.16.1.3 Release Notes
 
 ## Download information
- * Source: [rpm-4.16.1.3.tar.bz2](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.3.tar.bz2)
+ * Source: [rpm-4.16.1.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.3.tar.bz2)
  * SHA256SUM: 513dc7f972b6e7ccfc9fc7f9c01d5310cc56ee853892e4314fa2cad71478e21d
 
 ## Summary of changes from RPM 4.16.1.2

--- a/wiki/Releases/4.16.1.md
+++ b/wiki/Releases/4.16.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.16.1 Release Notes
 
 ## Download information
- * Source: [rpm-4.16.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.16.x/rpm-4.16.1.tar.bz2)
+ * Source: [rpm-4.16.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.16.x/rpm-4.16.1.tar.bz2)
  * SHA256SUM: 4650cb9d414704059a6e0bee73a68a13bb367dfce188bd35f56b19e13a775cbf
 
 ## Summary of changes from RPM 4.16.0

--- a/wiki/Releases/4.17.0.md
+++ b/wiki/Releases/4.17.0.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.17.0-alpha Release Notes (DRAFT)
 
 ## Download information
- * Source: [rpm-4.16.90-git15395.tar.bz2](http://ftp.rpm.org/releases/testing/rpm-4.16.90-git15395.tar.bz2)
+ * Source: [rpm-4.16.90-git15395.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/testing/rpm-4.16.90-git15395.tar.bz2)
  * SHA256SUM: e047705d7e73fb7af76b2b6d5cff311bf31f3b9530f1cadee62758a37ad65606
 
 ## Summary of changes from RPM 4.16.x

--- a/wiki/Releases/4.4.2.1.md
+++ b/wiki/Releases/4.4.2.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.1
 
 ## Download information
- * [rpm-4.4.2.1.tar.gz](http://ftp.rpm.org/releases/rpm-4.4.x/rpm-4.4.2.1.tar.gz) source
+ * [rpm-4.4.2.1.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.1.tar.gz) source
  * SHA1SUM: d3a6c7f9f8f42849cad80cb6d3ddbe7ce2e72782
 
 ## Changes from version 4.4.2 to 4.4.2.1

--- a/wiki/Releases/4.4.2.1.md
+++ b/wiki/Releases/4.4.2.1.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.1
 
 ## Download information
- * [rpm-4.4.2.1.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.1.tar.gz) source
+ * [rpm-4.4.2.1.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.4.x/rpm-4.4.2.1.tar.gz) source
  * SHA1SUM: d3a6c7f9f8f42849cad80cb6d3ddbe7ce2e72782
 
 ## Changes from version 4.4.2 to 4.4.2.1

--- a/wiki/Releases/4.4.2.2.md
+++ b/wiki/Releases/4.4.2.2.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.2
 
 ## Download information
- * [rpm-4.4.2.2.tar.gz](http://ftp.rpm.org/releases/rpm-4.4.x/rpm-4.4.2.2.tar.gz) source
+ * [rpm-4.4.2.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.2.tar.gz) source
  * SHA1SUM: e69dc7898de34ffc82b33fa5a01285e62681c972
 
 ## Changes from version 4.4.2.1 to 4.4.2.2

--- a/wiki/Releases/4.4.2.2.md
+++ b/wiki/Releases/4.4.2.2.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.2
 
 ## Download information
- * [rpm-4.4.2.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.2.tar.gz) source
+ * [rpm-4.4.2.2.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.4.x/rpm-4.4.2.2.tar.gz) source
  * SHA1SUM: e69dc7898de34ffc82b33fa5a01285e62681c972
 
 ## Changes from version 4.4.2.1 to 4.4.2.2

--- a/wiki/Releases/4.4.2.3.md
+++ b/wiki/Releases/4.4.2.3.md
@@ -58,7 +58,7 @@ title: rpm.org - Releases
  * convert '-' to '_' within --define macro names ([RhBug:124995](https://bugzilla.redhat.com/show_bug.cgi?id=124995))
  * handle spaces in file path arguments correctly ([RhBug:217258](https://bugzilla.redhat.com/show_bug.cgi?id=217258))
  * avoid access(2) quirks querying symlinks, lstat(2) instead ([RhBug:60288](https://bugzilla.redhat.com/show_bug.cgi?id=60288))
- * permit files with glob characters in *.rpm packages ([#147383](http://rpm.org/ticket/147383))
+ * permit files with glob characters in *.rpm packages ([#147383](https://rpm.org/ticket/147383))
  * add support for triggerprein scriptlets
  * add support for Geode CPU ([RhBug:428979](https://bugzilla.redhat.com/show_bug.cgi?id=428979))
  * missing space in russian translation (MdvBug:36974)

--- a/wiki/Releases/4.4.2.3.md
+++ b/wiki/Releases/4.4.2.3.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.3
 
 ## Download information
- * [rpm-4.4.2.3.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.3.tar.gz) source
+ * [rpm-4.4.2.3.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.4.x/rpm-4.4.2.3.tar.gz) source
  * SHA1SUM: 10311c6404796507f193323d387c5e3f79e72d6b
 
 ## Changes from version 4.4.2.2 to 4.4.2.3

--- a/wiki/Releases/4.4.2.3.md
+++ b/wiki/Releases/4.4.2.3.md
@@ -6,7 +6,7 @@ title: rpm.org - Releases
 # RPM 4.4.2.3
 
 ## Download information
- * [rpm-4.4.2.3.tar.gz](http://ftp.rpm.org/releases/rpm-4.4.x/rpm-4.4.2.3.tar.gz) source
+ * [rpm-4.4.2.3.tar.gz](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.4.x/rpm-4.4.2.3.tar.gz) source
  * SHA1SUM: 10311c6404796507f193323d387c5e3f79e72d6b
 
 ## Changes from version 4.4.2.2 to 4.4.2.3

--- a/wiki/Releases/4.5.90.md
+++ b/wiki/Releases/4.5.90.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 *This page is outdated, see [4.6.0 draft release notes](4.6.0.html) for up-to-date information.*
 
 ## Download information
- * [rpm-4.5.90.git8514.tar.bz2](http://ftp.rpm.org/releases/testing/rpm-4.5.90.git8514.tar.bz2) source
+ * [rpm-4.5.90.git8514.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/testing/rpm-4.5.90.git8514.tar.bz2) source
  * SHA1SUM: 5b4f634dca69693e9c1d758b38dfea92e53bf2dd
 
 ## Summary of changes since RPM 4.4.x (INCOMPLETE DRAFT)

--- a/wiki/Releases/4.6.0.md
+++ b/wiki/Releases/4.6.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.6.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.6.x/rpm-4.6.0.tar.bz2) source
+ * [rpm-4.6.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.6.x/rpm-4.6.0.tar.bz2) source
  * SHA1SUM: 71906c70abdb815cbcdaccacf0fd76862cfe565c
 
 ## Summary of changes from RPM 4.4.x

--- a/wiki/Releases/4.6.0.md
+++ b/wiki/Releases/4.6.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.6.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.6.x/rpm-4.6.0.tar.bz2) source
+ * [rpm-4.6.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.6.x/rpm-4.6.0.tar.bz2) source
  * SHA1SUM: 71906c70abdb815cbcdaccacf0fd76862cfe565c
 
 ## Summary of changes from RPM 4.4.x

--- a/wiki/Releases/4.6.1.md
+++ b/wiki/Releases/4.6.1.md
@@ -34,7 +34,7 @@ title: rpm.org - Releases
  * Disallow path name components (~, / and ..) in name, version and release tags ([RhBug:493157](https://bugzilla.redhat.com/show_bug.cgi?id=493157)) 
  * Update rpmrc defaults to use -mtune instead of deprecated -mcpu ([RhBug:493696](https://bugzilla.redhat.com/show_bug.cgi?id=493696)) 
  * Add ISA-macros for Alpha architecture
- * Fix --with-kde with KDE3 (rhbz[#466009](http://rpm.org/ticket/466009))
+ * Fix --with-kde with KDE3 (rhbz[#466009](https://rpm.org/ticket/466009))
 
 ### Python bindings
  * Catch exceptions from Python string/number conversions in ts.dbMatch()

--- a/wiki/Releases/4.6.1.md
+++ b/wiki/Releases/4.6.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.6.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.6.x/rpm-4.6.1.tar.bz2) source
+ * [rpm-4.6.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.6.x/rpm-4.6.1.tar.bz2) source
  * SHA1SUM: ba04de85a37ab10c203ef1cfbf291cb8c195cc3b
 
 ## Summary of changes from rpm 4.6.0

--- a/wiki/Releases/4.6.1.md
+++ b/wiki/Releases/4.6.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.6.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.6.x/rpm-4.6.1.tar.bz2) source
+ * [rpm-4.6.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.6.x/rpm-4.6.1.tar.bz2) source
  * SHA1SUM: ba04de85a37ab10c203ef1cfbf291cb8c195cc3b
 
 ## Summary of changes from rpm 4.6.0

--- a/wiki/Releases/4.7.0.md
+++ b/wiki/Releases/4.7.0.md
@@ -96,7 +96,7 @@ title: rpm.org - Releases
 
 ### Build process
  * Much improved build-time self-test suite.
- * Various Hurd portability fixes. (ticket [#3](https://rpm.org/ticket/3), [#4](http://rpm.org/ticket/4) and [#5](http://rpm.org/ticket/5)).
+ * Various Hurd portability fixes. (ticket [#3](https://rpm.org/ticket/3), [#4](https://rpm.org/ticket/4) and [#5](https://rpm.org/ticket/5)).
  * A handful of remaining compiler warnings have been eliminated.
  * Some linkage cleanups (avoid linking to unnecessary libraries)
  * Optional new build-dependencies:

--- a/wiki/Releases/4.7.0.md
+++ b/wiki/Releases/4.7.0.md
@@ -38,7 +38,7 @@ title: rpm.org - Releases
 ### Package building
  * Disallow path name components (~, / and ..) in name, version and release tags ([RhBug:493157](https://bugzilla.redhat.com/show_bug.cgi?id=493157))
  * Changelog timestamps are always in UTC to avoid "time warp" syndrome
- * rpmbuild can be configured to run a post-build package checker such as rpmlint. (ticket [#2](http://rpm.org/ticket/2))
+ * rpmbuild can be configured to run a post-build package checker such as rpmlint. (ticket [#2](https://rpm.org/ticket/2))
  * %patch default arguments can now be controlled with %_default_patch_flags macro. ([RhBug:471006](https://bugzilla.redhat.com/show_bug.cgi?id=471006))
  * Package build dependencies are no longer needlessly checked on --rmsource. ([RhBug:452477](https://bugzilla.redhat.com/show_bug.cgi?id=452477))
  * Don't require sources and patches to be present for --rmspec to work. ([RhBug:472427](https://bugzilla.redhat.com/show_bug.cgi?id=472427))
@@ -62,7 +62,7 @@ title: rpm.org - Releases
    * rpmConfigDir() function for retrieving rpm configuration dir as been added.
    * Header "magic" value is now exported as rpm_header_magic symbol.
    * headerGet() can now return string arrays as argv-style NULL-terminated array.
-   * "Class" of tag type can now be directly retrieved with new rpmTagTypeGetClass() function. This is mainly relevant for tag extensions whose type can differ from the one specified in rpm tag table. (ticket [#25](http://rpm.org/ticket/25))
+   * "Class" of tag type can now be directly retrieved with new rpmTagTypeGetClass() function. This is mainly relevant for tag extensions whose type can differ from the one specified in rpm tag table. (ticket [#25](https://rpm.org/ticket/25))
  * The following API calls have been removed. No known API user is affected, these have only been used by RPM itself internally:
    * rpmfiFContext() function for retrieving SELinux contexts from header has been removed. Rpm headers do not have SELinux contexts so this was non-sensical.
    * rpmfiTypeString() function for retrieving the "type" of file info set has been removed. File info sets have no type, transaction elements do.
@@ -96,7 +96,7 @@ title: rpm.org - Releases
 
 ### Build process
  * Much improved build-time self-test suite.
- * Various Hurd portability fixes. (ticket [#3](http://rpm.org/ticket/3), [#4](http://rpm.org/ticket/4) and [#5](http://rpm.org/ticket/5)).
+ * Various Hurd portability fixes. (ticket [#3](https://rpm.org/ticket/3), [#4](http://rpm.org/ticket/4) and [#5](http://rpm.org/ticket/5)).
  * A handful of remaining compiler warnings have been eliminated.
  * Some linkage cleanups (avoid linking to unnecessary libraries)
  * Optional new build-dependencies:

--- a/wiki/Releases/4.7.0.md
+++ b/wiki/Releases/4.7.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.7.x/rpm-4.7.0.tar.bz2) source
+ * [rpm-4.7.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.0.tar.bz2) source
  * SHA1SUM: f871df62eb4fcdbb67d3eca9772688cf80fb1cdd
 
 ## Summary of changes from RPM 4.6.x

--- a/wiki/Releases/4.7.0.md
+++ b/wiki/Releases/4.7.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.0.tar.bz2) source
+ * [rpm-4.7.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.7.x/rpm-4.7.0.tar.bz2) source
  * SHA1SUM: f871df62eb4fcdbb67d3eca9772688cf80fb1cdd
 
 ## Summary of changes from RPM 4.6.x

--- a/wiki/Releases/4.7.1.md
+++ b/wiki/Releases/4.7.1.md
@@ -33,7 +33,7 @@ title: rpm.org - Releases
  * Don't accept '-' for stdin in manifest files ([RhBug:461353](https://bugzilla.redhat.com/show_bug.cgi?id=461353))
  * Fix rpm.unregister() Lua extension
  * Handle rpmhook unregistering itself correctly
- * Add -h/--help option to rpm2cpio (ticket [#63](http://rpm.org/ticket/63))
+ * Add -h/--help option to rpm2cpio (ticket [#63](https://rpm.org/ticket/63))
  * Various minor documentation + translation fixes and updates ([RhBug:482921](https://bugzilla.redhat.com/show_bug.cgi?id=482921))
 
 ### Package building
@@ -41,10 +41,10 @@ title: rpm.org - Releases
  * Fix calculation of hardlinked file sizes ([RhBug:503020](https://bugzilla.redhat.com/show_bug.cgi?id=503020))
  * Map legacy PreReq tag into Requires(pre,preun) at build for closer mapping to former semantics
  * Add DWARF-3 support to debugedit ([RhBug:505774](https://bugzilla.redhat.com/show_bug.cgi?id=505774))
- * %files now accepts multiple filelists (ticket [#70](http://rpm.org/ticket/70), [RhBug:475359](https://bugzilla.redhat.com/show_bug.cgi?id=475359))
+ * %files now accepts multiple filelists (ticket [#70](https://rpm.org/ticket/70), [RhBug:475359](https://bugzilla.redhat.com/show_bug.cgi?id=475359))
  * Base64-encode %policy files to ensure they can be stored as \0-terminated strings in header
- * Much improved OSGi dependency generator script (ticket [#39](http://rpm.org/ticket/39))
- * Some typos fixed in javadeps (ticket [#72](http://rpm.org/ticket/72))
+ * Much improved OSGi dependency generator script (ticket [#39](https://rpm.org/ticket/39))
+ * Some typos fixed in javadeps (ticket [#72](https://rpm.org/ticket/72))
 
 ### Internal improvements
  * Restore former value of RPMSENSE_PREREQ, permitting it to be tested again
@@ -56,4 +56,4 @@ title: rpm.org - Releases
 
 ### Build process
  * Fix permissions of some non-executable macro etc files
- * Fix building outside source directory (ticket [#65](http://rpm.org/ticket/65))
+ * Fix building outside source directory (ticket [#65](https://rpm.org/ticket/65))

--- a/wiki/Releases/4.7.1.md
+++ b/wiki/Releases/4.7.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.7.x/rpm-4.7.1.tar.bz2) source
+ * [rpm-4.7.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.1.tar.bz2) source
  * SHA1SUM: 45da31c209337d085d70c0183b6d7c9b89daa6c6
 
 ## Summary of changes from rpm 4.7.0

--- a/wiki/Releases/4.7.1.md
+++ b/wiki/Releases/4.7.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.1.tar.bz2) source
+ * [rpm-4.7.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.7.x/rpm-4.7.1.tar.bz2) source
  * SHA1SUM: 45da31c209337d085d70c0183b6d7c9b89daa6c6
 
 ## Summary of changes from rpm 4.7.0

--- a/wiki/Releases/4.7.2.md
+++ b/wiki/Releases/4.7.2.md
@@ -21,27 +21,27 @@ title: rpm.org - Releases
  * Fix ftp/http proxy options ([RhBug:529214](https://bugzilla.redhat.com/show_bug.cgi?id=529214)) (regression originating from 4.6.0)
  * Skip %posttrans scripts of failed transaction elements
  * Disk space problems are only reported for affected packages ([RhBug:517418](https://bugzilla.redhat.com/show_bug.cgi?id=517418))
- * Error out early when trying to install to readonly filesystem (ticket [#99](http://rpm.org/ticket/99), [RhBug:464750](https://bugzilla.redhat.com/show_bug.cgi?id=464750))
+ * Error out early when trying to install to readonly filesystem (ticket [#99](https://rpm.org/ticket/99), [RhBug:464750](https://bugzilla.redhat.com/show_bug.cgi?id=464750))
  * Database files and indexes are opened with relative paths, avoiding issues with chroot ([RhBug:507309](https://bugzilla.redhat.com/show_bug.cgi?id=507309) & others)
  * Remove DB4 environment on close when chrooted ([RhBug:513699](https://bugzilla.redhat.com/show_bug.cgi?id=513699), [RhBug:507309](https://bugzilla.redhat.com/show_bug.cgi?id=507309)...)
  * Improve file list query (-ql) speed in normal case
  * Minor memory leaks fixed
- * Convert French man page to Unix line-endings (ticket [#104](http://rpm.org/ticket/104))
+ * Convert French man page to Unix line-endings (ticket [#104](https://rpm.org/ticket/104))
 
 ### Package building
  * Fix segfault when on %include of empty files
- * Fix %sources and %patches containing the same items multiple times (ticket [#82](http://rpm.org/ticket/82))
- * Fix duplicate dependency checking on build (ticket [#103](http://rpm.org/ticket/103), [RhBug:490378](https://bugzilla.redhat.com/show_bug.cgi?id=490378))
+ * Fix %sources and %patches containing the same items multiple times (ticket [#82](https://rpm.org/ticket/82))
+ * Fix duplicate dependency checking on build (ticket [#103](https://rpm.org/ticket/103), [RhBug:490378](https://bugzilla.redhat.com/show_bug.cgi?id=490378))
  * Allow absolute paths in file lists again (SuseBug:535594, [RhBug:521760](https://bugzilla.redhat.com/show_bug.cgi?id=521760)) (regression in 4.7.1)
  * Use 444 permissions for all .debug files ([RhBug:522194](https://bugzilla.redhat.com/show_bug.cgi?id=522194))
- * Add XZ and LZMA recompress support to brp-compress (ticket [#84](http://rpm.org/ticket/84))
- * OSGi dependency generator fixes (ticket [#101](http://rpm.org/ticket/101))
+ * Add XZ and LZMA recompress support to brp-compress (ticket [#84](https://rpm.org/ticket/84))
+ * OSGi dependency generator fixes (ticket [#101](https://rpm.org/ticket/101))
  * Improved perl heredoc parsing ([RhBug:524929](https://bugzilla.redhat.com/show_bug.cgi?id=524929))
 
 ### Build process
- * Add missing include in rpmsq.h (ticket [#78](http://rpm.org/ticket/78))
+ * Add missing include in rpmsq.h (ticket [#78](https://rpm.org/ticket/78))
  * Fix build with Berkeley DB 4.8.x
- * Fix build with binutils-gold (ticket [#107](http://rpm.org/ticket/107))
- * Fix out of source directory build when Lua enabled (ticket [#91](http://rpm.org/ticket/91))
- * Remove bogus rpmpopt.pot file (ticket [#77](http://rpm.org/ticket/77))
+ * Fix build with binutils-gold (ticket [#107](https://rpm.org/ticket/107))
+ * Fix out of source directory build when Lua enabled (ticket [#91](https://rpm.org/ticket/91))
+ * Remove bogus rpmpopt.pot file (ticket [#77](https://rpm.org/ticket/77))
  

--- a/wiki/Releases/4.7.2.md
+++ b/wiki/Releases/4.7.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.7.x/rpm-4.7.2.tar.bz2) source
+ * [rpm-4.7.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.2.tar.bz2) source
  * SHA1SUM: 07b90f653775329ea726ce0005c4c82f56167ca0
 
 ## Summary of changes from rpm 4.7.1

--- a/wiki/Releases/4.7.2.md
+++ b/wiki/Releases/4.7.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.7.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.7.x/rpm-4.7.2.tar.bz2) source
+ * [rpm-4.7.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.7.x/rpm-4.7.2.tar.bz2) source
  * SHA1SUM: 07b90f653775329ea726ce0005c4c82f56167ca0
 
 ## Summary of changes from rpm 4.7.1

--- a/wiki/Releases/4.8.0.md
+++ b/wiki/Releases/4.8.0.md
@@ -49,7 +49,7 @@ title: rpm.org - Releases
  * %_netsharedpath is evaluated for erasures too ([RhBug:494640](https://bugzilla.redhat.com/show_bug.cgi?id=494640))
  * Validate rpmlib() dependencies on src.rpm install ([RhBug:490613](https://bugzilla.redhat.com/show_bug.cgi?id=490613))
  * Various minor corner-case memory leaks fixed
- * Several documentation fixes (ticket [#72](https://rpm.org/ticket/72), [#63](http://rpm.org/ticket/63))
+ * Several documentation fixes (ticket [#72](https://rpm.org/ticket/72), [#63](https://rpm.org/ticket/63))
  * Several translation updates (Spanish, Portugese Brasilian, Polish, German, Japanese, French, Serbian)
 
 ### Package building

--- a/wiki/Releases/4.8.0.md
+++ b/wiki/Releases/4.8.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.8.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.8.x/rpm-4.8.0.tar.bz2) source
+ * [rpm-4.8.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.8.x/rpm-4.8.0.tar.bz2) source
  * SHA1SUM: 84210ab42f36ad6b3d856c86a974a5178d1de864
 
 ## Summary of changes from RPM 4.7.x

--- a/wiki/Releases/4.8.0.md
+++ b/wiki/Releases/4.8.0.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.8.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.8.x/rpm-4.8.0.tar.bz2) source
+ * [rpm-4.8.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.8.x/rpm-4.8.0.tar.bz2) source
  * SHA1SUM: 84210ab42f36ad6b3d856c86a974a5178d1de864
 
 ## Summary of changes from RPM 4.7.x

--- a/wiki/Releases/4.8.0.md
+++ b/wiki/Releases/4.8.0.md
@@ -39,17 +39,17 @@ title: rpm.org - Releases
    * :vflags (human readable file verifyflags information)
  * Major speed improvement in file list queries (eg -qal)
  * Major speed improvements in installation dependency calculations
- * Error out early when trying to install to readonly filesystem (ticket [#99](http://rpm.org/ticket/99), [RhBug:464750](https://bugzilla.redhat.com/show_bug.cgi?id=464750))
+ * Error out early when trying to install to readonly filesystem (ticket [#99](https://rpm.org/ticket/99), [RhBug:464750](https://bugzilla.redhat.com/show_bug.cgi?id=464750))
  * Disk space problems are only reported for affected packages ([RhBug:517418](https://bugzilla.redhat.com/show_bug.cgi?id=517418))
  * Skip %posttrans scriptlets of failed transaction elements
- * Package erasures are now ordered too (ticket [#48](http://rpm.org/ticket/48), [RhBug:479257](https://bugzilla.redhat.com/show_bug.cgi?id=479257), [RhBug:448153](https://bugzilla.redhat.com/show_bug.cgi?id=448153)
- * Improved ordering of packages with dependency loops - loopy sets are now guaranteed to be installed together (ticket [#51](http://rpm.org/ticket/51))
+ * Package erasures are now ordered too (ticket [#48](https://rpm.org/ticket/48), [RhBug:479257](https://bugzilla.redhat.com/show_bug.cgi?id=479257), [RhBug:448153](https://bugzilla.redhat.com/show_bug.cgi?id=448153)
+ * Improved ordering of packages with dependency loops - loopy sets are now guaranteed to be installed together (ticket [#51](https://rpm.org/ticket/51))
  * Install ordering now differentiates between "colored" dependencies, giving better order with multilib package sets
  * Handle Requires(pre,preun) ordering correctly on erasure
  * %_netsharedpath is evaluated for erasures too ([RhBug:494640](https://bugzilla.redhat.com/show_bug.cgi?id=494640))
  * Validate rpmlib() dependencies on src.rpm install ([RhBug:490613](https://bugzilla.redhat.com/show_bug.cgi?id=490613))
  * Various minor corner-case memory leaks fixed
- * Several documentation fixes (ticket [#72](http://rpm.org/ticket/72), [#63](http://rpm.org/ticket/63))
+ * Several documentation fixes (ticket [#72](https://rpm.org/ticket/72), [#63](http://rpm.org/ticket/63))
  * Several translation updates (Spanish, Portugese Brasilian, Polish, German, Japanese, French, Serbian)
 
 ### Package building
@@ -57,31 +57,31 @@ title: rpm.org - Releases
  * Automatic extraction of OCaml dependencies
  * Automatic extraction of mime-handler provides from .desktop files
  * Automatic extraction of font provides
- * OSGi dependency generator fixes (ticket [#101](http://rpm.org/ticket/101))
+ * OSGi dependency generator fixes (ticket [#101](https://rpm.org/ticket/101))
  * Extra options can be now specified and passed to dependency extractor scripts
- * %files now accepts multiple filelists through -f (ticket [#70](http://rpm.org/ticket/70), [RhBug:475359](https://bugzilla.redhat.com/show_bug.cgi?id=475359))
+ * %files now accepts multiple filelists through -f (ticket [#70](https://rpm.org/ticket/70), [RhBug:475359](https://bugzilla.redhat.com/show_bug.cgi?id=475359))
  * Use 444 permissions for all .debug files ([RhBug:522194](https://bugzilla.redhat.com/show_bug.cgi?id=522194))
  * Handle .desktop files with spaces in filename ([RhBug:520920](https://bugzilla.redhat.com/show_bug.cgi?id=520920))
  * Fix duplicate dependency checking on build ([RhBug:490378](https://bugzilla.redhat.com/show_bug.cgi?id=490378))
- * Various commonly used Python macros added (ticket [#83](http://rpm.org/ticket/83))
+ * Various commonly used Python macros added (ticket [#83](https://rpm.org/ticket/83))
  * Support for multiple major python versions in brp-python-bytecompile ([RhBug:531117](https://bugzilla.redhat.com/show_bug.cgi?id=531117))
  * Packages can now have a separate bug reporting url by setting BugUrl in spec or through %_bugurl in macro configuration ([RhBug:512774](https://bugzilla.redhat.com/show_bug.cgi?id=512774))
- * Fix %sources and %patches containing the same items multiple times (ticket [#82](http://rpm.org/ticket/82))
- * Add default %clean section unless overridden in spec (ticket [#81](http://rpm.org/ticket/81))
- * %patch macro supports new -d option (ticket [#69](http://rpm.org/ticket/69))
+ * Fix %sources and %patches containing the same items multiple times (ticket [#82](https://rpm.org/ticket/82))
+ * Add default %clean section unless overridden in spec (ticket [#81](https://rpm.org/ticket/81))
+ * %patch macro supports new -d option (ticket [#69](https://rpm.org/ticket/69))
  * New %make_install macro which does the right thing wrt modern autotools (ie "make install DESTDIR=...")
  * Unset CDPATH (and DISPLAY) environment variables on build-scripts ([RhBug:426955](https://bugzilla.redhat.com/show_bug.cgi?id=426955))
  * Always run build-scripts in C-locale
  * Don't set --target in %configure ([RhBug:458648](https://bugzilla.redhat.com/show_bug.cgi?id=458648))
  * Fix segfault on %include of empty file
- * Add XZ and LZMA recompress support to brp-compress (ticket [#84](http://rpm.org/ticket/84))
+ * Add XZ and LZMA recompress support to brp-compress (ticket [#84](https://rpm.org/ticket/84))
  * Correctly inherit default %attr(-,-,-) from %defattr ([RhBug:515685](https://bugzilla.redhat.com/show_bug.cgi?id=515685))
  * Support DWARF-3 in debugedit ([RhBug:505774](https://bugzilla.redhat.com/show_bug.cgi?id=505774))
- * Much stricter set of allowed characters in various tags like Name, Version etc (ticket [#59](http://rpm.org/ticket/59), [RhBug:493157](https://bugzilla.redhat.com/show_bug.cgi?id=493157))
+ * Much stricter set of allowed characters in various tags like Name, Version etc (ticket [#59](https://rpm.org/ticket/59), [RhBug:493157](https://bugzilla.redhat.com/show_bug.cgi?id=493157))
  * PreReq and BuildPreReq are now officially deprecated, with warnings at build-time
  * PreReq is mapped to Requires(pre,preun) at build-time
  * Permit %ghost to be used on non-existent files ([RhBug:495040](https://bugzilla.redhat.com/show_bug.cgi?id=495040))
- * Configurable changelog trimming in rpm files (ticket [#47](http://rpm.org/ticket/47))
+ * Configurable changelog trimming in rpm files (ticket [#47](https://rpm.org/ticket/47))
  * Error out on unsupported payload compressor ([RhBug:495429](https://bugzilla.redhat.com/show_bug.cgi?id=495429))
  * Correctly handle "./" in file paths ([RhBug:491388](https://bugzilla.redhat.com/show_bug.cgi?id=491388))
  * Various tweaks to the internal file classifier ([RhBug:491349](https://bugzilla.redhat.com/show_bug.cgi?id=491349))
@@ -164,7 +164,7 @@ title: rpm.org - Releases
 
 #### Spec class
  * Spec object instanciation has been decoupled from transaction objects and can now be directly instanciated by calling the spec constructor
- * Allow accessing spec package structures from Python (ticket [#14](http://rpm.org/ticket/14), [RhBug:46726](https://bugzilla.redhat.com/show_bug.cgi?id=46726))
+ * Allow accessing spec package structures from Python (ticket [#14](https://rpm.org/ticket/14), [RhBug:46726](https://bugzilla.redhat.com/show_bug.cgi?id=46726))
  * Former spec object methods have been converted to object attributes instead (incompatible)
 
 #### New classes
@@ -184,8 +184,8 @@ title: rpm.org - Releases
  * Support for ambiguous cmp() has been removed from header objects. Use rpm.versionCompare() instead.
 
 ### Build process
- * Fix building with binutils-gold (ticket [#107](http://rpm.org/ticket/107))
- * Fix out-of-tree build when Lua enabled (ticket [#91](http://rpm.org/ticket/91))
+ * Fix building with binutils-gold (ticket [#107](https://rpm.org/ticket/107))
+ * Fix out-of-tree build when Lua enabled (ticket [#91](https://rpm.org/ticket/91))
  * Linkage cleanups
 
 ## Compatibility notes

--- a/wiki/Releases/4.8.1.md
+++ b/wiki/Releases/4.8.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.8.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.8.x/rpm-4.8.1.tar.bz2) source
+ * [rpm-4.8.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.8.x/rpm-4.8.1.tar.bz2) source
  * SHA1SUM: 5811168721f6caa3fb883ebd491c8c5416d9bf57
 
 ## Summary of changes from RPM 4.8.0

--- a/wiki/Releases/4.8.1.md
+++ b/wiki/Releases/4.8.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.8.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.8.x/rpm-4.8.1.tar.bz2) source
+ * [rpm-4.8.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.8.x/rpm-4.8.1.tar.bz2) source
  * SHA1SUM: 5811168721f6caa3fb883ebd491c8c5416d9bf57
 
 ## Summary of changes from RPM 4.8.0

--- a/wiki/Releases/4.8.1.md
+++ b/wiki/Releases/4.8.1.md
@@ -28,7 +28,7 @@ title: rpm.org - Releases
  * Fix :deptype header format extension failing to show some flag combinations
  * Fix error message on package conflicts against installed packages
  * Fix erased packages causing misleading disk-space checking messages ([RhBug:561160](https://bugzilla.redhat.com/show_bug.cgi?id=561160))
- * Document --conflicts option in manpage (ticket [#126](http://rpm.org/ticket/126))
+ * Document --conflicts option in manpage (ticket [#126](https://rpm.org/ticket/126))
 
 ### Package building
  * Fix %defattr(-) syntax, regression introduced in  (SuseBug:594310)
@@ -36,7 +36,7 @@ title: rpm.org - Releases
  * Fix NOSOURCE/NOPATCH tag generation of nosrc packages, regression introduced in 4.6.0
  * Fix crash in the spec parser ([RhBug:597835](https://bugzilla.redhat.com/show_bug.cgi?id=597835), SuseBug:582599)
  * Fix copying of translated tags into source rpms ([RhBug:578299](https://bugzilla.redhat.com/show_bug.cgi?id=578299))
- * Only extract dependencies from .desktop files with Type=Application and Exec= entries (ticket [#150](http://rpm.org/ticket/150))
+ * Only extract dependencies from .desktop files with Type=Application and Exec= entries (ticket [#150](https://rpm.org/ticket/150))
  * Work around GNU tar debug output breaking rpmbuild -t (SuseBug:558475)
 
 ### API changes
@@ -53,11 +53,11 @@ title: rpm.org - Releases
 
 ### Python bindings
  * Handle non-existent dependency sets from headers correctly, regression introduced in 4.8.0 ([RhBug:593553](https://bugzilla.redhat.com/show_bug.cgi?id=593553))
- * Fix match iterator boolean presentation, regression introduced in 4.8.0 (ticket [#153](http://rpm.org/ticket/153))
+ * Fix match iterator boolean presentation, regression introduced in 4.8.0 (ticket [#153](https://rpm.org/ticket/153))
  * Add __version__ and __version_info__ constants for rpm version information
- * Add RPMBUILD_ISSOURCE/PATCH/ICON/NO constants (ticket [#123](http://rpm.org/ticket/123))
+ * Add RPMBUILD_ISSOURCE/PATCH/ICON/NO constants (ticket [#123](https://rpm.org/ticket/123))
  * Add RPMTRANS_FLAG_NOCONTEXTS constant ([RhBug:573111](https://bugzilla.redhat.com/show_bug.cgi?id=573111))
- * Document deprecation of mi.count() and ds.Count() (ticket [#152](http://rpm.org/ticket/152))
+ * Document deprecation of mi.count() and ds.Count() (ticket [#152](https://rpm.org/ticket/152))
 
 ### Build process
  * Fix missing __fxstat64() symbol on Mac OS X

--- a/wiki/Releases/4.9.0.md
+++ b/wiki/Releases/4.9.0.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 ### RPM 4.9.0
- * [rpm-4.9.0.tar.bz2](http://ftp.rpm.org/releases/rpm-4.9.x/rpm-4.9.0.tar.bz2) source
+ * [rpm-4.9.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.0.tar.bz2) source
  * SHA1SUM: 6bb5a392705ef6edad26c305f9bc9b6ac66ab47d
 
 ## Summary of changes from RPM 4.8.x

--- a/wiki/Releases/4.9.0.md
+++ b/wiki/Releases/4.9.0.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
 ### RPM 4.9.0
- * [rpm-4.9.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.0.tar.bz2) source
+ * [rpm-4.9.0.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.9.x/rpm-4.9.0.tar.bz2) source
  * SHA1SUM: 6bb5a392705ef6edad26c305f9bc9b6ac66ab47d
 
 ## Summary of changes from RPM 4.8.x

--- a/wiki/Releases/4.9.0.md
+++ b/wiki/Releases/4.9.0.md
@@ -18,17 +18,17 @@ title: rpm.org - Releases
  * Improved install/erase/upgrade failure handling: elements skipped due to earlier failure cause their dependent elements to get skipped too, and all failed and skipped elements are logged.
  * Rpm now refuses to install packages which are obsoleted by an already installed package ([RhBug:486565](https://bugzilla.redhat.com/show_bug.cgi?id=486565))
  * Obsoletion within install set is handled automatically: obsoleting package replaces obsoleted package in the transaction set.
- * Allow installation of self-conflicting packages, this can be used eg for creating "singleton" behavior between alternatives ([#806](http://rpm.org/ticket/806), [RhBug:651951](https://bugzilla.redhat.com/show_bug.cgi?id=651951))
+ * Allow installation of self-conflicting packages, this can be used eg for creating "singleton" behavior between alternatives ([#806](https://rpm.org/ticket/806), [RhBug:651951](https://bugzilla.redhat.com/show_bug.cgi?id=651951))
  * Dependency matching behaves more consistently in corner cases where release value is missing.
  * Rpm now detects initial installation (eg install to an empty chroot) and disables fsync()/fdatasync() calls for the duration of that transaction, resulting in much faster install when there's no existing data to protect.
  * Database operations (including package install/erase) are much faster due to fewer indexes.
- * Disk space accounting now considers the estimated size requirements of the rpm database too ([#26](http://rpm.org/ticket/26))
+ * Disk space accounting now considers the estimated size requirements of the rpm database too ([#26](https://rpm.org/ticket/26))
  * -F/--freshen now takes architecture into consideration on multilib systems ([RhBug:553108](https://bugzilla.redhat.com/show_bug.cgi?id=553108))
  * --nocontexts now also disables SELinux context change when executing scriptlets.
 
  * --info/-i query format has been changed to much more readable single "tag: value" per line formatting. Also epoch, architecture and bugurl are included in the output ([RhBug:575499](https://bugzilla.redhat.com/show_bug.cgi?id=575499))
  * All dependency bits are now reported in :deptype format extension
- * Spec queries can now be performed on both binary and source headers ([RhBug:540807](https://bugzilla.redhat.com/show_bug.cgi?id=540807), ticket [#89](http://rpm.org/ticket/89))
+ * Spec queries can now be performed on both binary and source headers ([RhBug:540807](https://bugzilla.redhat.com/show_bug.cgi?id=540807), ticket [#89](https://rpm.org/ticket/89))
  * Fix crash on unknown tags in header iteration query formats such as --xml.
 
  * Fix bogus missing dependencies verify failures on package pre-requisites([RhBug:223642](https://bugzilla.redhat.com/show_bug.cgi?id=223642))
@@ -59,8 +59,8 @@ title: rpm.org - Releases
  * Packages can now supply extra transaction ordering hints via new OrderWithRequires tag. This follows Requires tag syntax, but does not generate actual dependencies. Only if the involved packages are present in the same transaction, the ordering hints are treated as if they were Requires when calculating the transaction order.
  * Support uncompressed package payloads
 
- * Numerous perl dependency generator fixes (tickets XXX, [#128](http://rpm.org/ticket/128), [RhBug:477516](https://bugzilla.redhat.com/show_bug.cgi?id=477516)...)
- * In simple cases, #!/usr/bin/env interpreter dependencies are now generated automatically ([#136](http://rpm.org/ticket/136))
+ * Numerous perl dependency generator fixes (tickets XXX, [#128](https://rpm.org/ticket/128), [RhBug:477516](https://bugzilla.redhat.com/show_bug.cgi?id=477516)...)
+ * In simple cases, #!/usr/bin/env interpreter dependencies are now generated automatically ([#136](https://rpm.org/ticket/136))
  * All parts of internal dependency generator are now implemented via external helpers and can be overridden via macros
  * Dependency generators are now pluggable. Arbitrary number of dependency types is supported, new types can be added through a drop-in directory and file classification is now done with a combination of path and libmagic-type include/exclude regular expressions (XXX add link to documentation once it exists)
  * Automatically generated dependencies can now be filtered with regex patterns. Entire paths can be completely excluded from dependency generation, and also individual generated dependencies can be excluded.
@@ -68,7 +68,7 @@ title: rpm.org - Releases
  * RPM_BUILD_ROOT environment variable is now always available in all build-scripts.
  * Default behavior of SIGPIPE is restored for build-scriptlets ([RhBug:651463](https://bugzilla.redhat.com/show_bug.cgi?id=651463))
 
- * Fix relative paths causing tarball to be accessed instead of spec (ticket [#137](http://rpm.org/ticket/137))
+ * Fix relative paths causing tarball to be accessed instead of spec (ticket [#137](https://rpm.org/ticket/137))
  * Short-circuiting binary builds is now allowed by rpmbuild for developer convenience while testing. Short-circuited packages are tainted with an unsatisfiable dependency to limit their use for the intended testing-only purpose.
 
  * Debuginfo generation now creates an index for speeding up GDB if possible ([RhBug:617166](https://bugzilla.redhat.com/show_bug.cgi?id=617166))
@@ -160,7 +160,7 @@ title: rpm.org - Releases
  * rpmcliFini() now performs all/most necessary memory cleanup calls for cli-use.
  * Calling rpmReadConfigFiles() no longer changes the process umask.
  * rpmdbInitIterator() and rpmtsInitIterator() now iterate over the indexes when "keyp" argument is NULL instead of returning empty iterators.
- * rpmdbInit() and rpmtsInitDB() now create all the secondary indexes too (ticket [#156](http://rpm.org/ticket/156))
+ * rpmdbInit() and rpmtsInitDB() now create all the secondary indexes too (ticket [#156](https://rpm.org/ticket/156))
  * Enum type abuse elimination changes:
    * The type of tag argument to rpmdbInitIterator() and rpmtsInitIterator() interfaces have been changed to indicate they take an rpmDbiTag (value) as the tag argument, not any arbitrary header tag. Using RPMTAG_* values still works though, as long as the corresponding index actually exists.
    * All uses of rpmTag and rpmSigTag enum types in function arguments have been changed to an integral rpmTagVal type
@@ -178,7 +178,7 @@ title: rpm.org - Releases
  * Numerous unnecessary compatibility workarounds/hacks from rpm 1.x - 2.x era have been removed
 
  * Scriptlet running mechanism has been cleaned up, decoupled from package state machine to an abstraction of their own, and no longer needs header(s) or even transaction set to execute. This is not really used yet, but technically would allow implementing things such as %postuntrans which hasn't been possible before.
- * The macro engine is no longer limited by pre-allocated static buffer sizes, the expansion buffer grows dynamically (ticket [#45](http://rpm.org/ticket/45))
+ * The macro engine is no longer limited by pre-allocated static buffer sizes, the expansion buffer grows dynamically (ticket [#45](https://rpm.org/ticket/45))
  * New secondary database indexes can be created on the fly without requiring a full database rebuild
  * The fundamental database configuration is now hardwired in librpm instead of being scattered around macro configuration, ensuring rpm is in control of its database and index formats and the underlying Berkeley DB subsystem configuration.
  * Dependency set color is only calculated on colored transactions, saving some memory on non-multilib systems.

--- a/wiki/Releases/4.9.1.1.md
+++ b/wiki/Releases/4.9.1.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.9.x/rpm-4.9.1.1.tar.bz2) source
+ * [rpm-4.9.1.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.1.tar.bz2) source
  * SHA1SUM: 10bad109911449dc0075e8f62f9b2c3b2175a67e
 
 ## Summary of changes from RPM 4.9.1

--- a/wiki/Releases/4.9.1.1.md
+++ b/wiki/Releases/4.9.1.1.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.1.tar.bz2) source
+ * [rpm-4.9.1.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.9.x/rpm-4.9.1.1.tar.bz2) source
  * SHA1SUM: 10bad109911449dc0075e8f62f9b2c3b2175a67e
 
 ## Summary of changes from RPM 4.9.1

--- a/wiki/Releases/4.9.1.2.md
+++ b/wiki/Releases/4.9.1.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.2.tar.bz2](http://ftp.rpm.org/releases/rpm-4.9.x/rpm-4.9.1.2.tar.bz2) source
+ * [rpm-4.9.1.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.2.tar.bz2) source
  * SHA1SUM: 5ec557424d90461f76d4ad30bfb6653b79920d58
 
 ## Summary of changes from RPM 4.9.1.1

--- a/wiki/Releases/4.9.1.2.md
+++ b/wiki/Releases/4.9.1.2.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.2.tar.bz2) source
+ * [rpm-4.9.1.2.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.9.x/rpm-4.9.1.2.tar.bz2) source
  * SHA1SUM: 5ec557424d90461f76d4ad30bfb6653b79920d58
 
 ## Summary of changes from RPM 4.9.1.1

--- a/wiki/Releases/4.9.1.3.md
+++ b/wiki/Releases/4.9.1.3.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.3.tar.bz2) source
+ * [rpm-4.9.1.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.9.x/rpm-4.9.1.3.tar.bz2) source
  * SHA1SUM: d1157a05a2368de07e06638daee01d3749107c8b
 
 ## Summary of changes from RPM 4.9.1.2

--- a/wiki/Releases/4.9.1.3.md
+++ b/wiki/Releases/4.9.1.3.md
@@ -8,7 +8,7 @@ title: rpm.org - Releases
 
 
 ## Download information
- * [rpm-4.9.1.3.tar.bz2](http://ftp.rpm.org/releases/rpm-4.9.x/rpm-4.9.1.3.tar.bz2) source
+ * [rpm-4.9.1.3.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.3.tar.bz2) source
  * SHA1SUM: d1157a05a2368de07e06638daee01d3749107c8b
 
 ## Summary of changes from RPM 4.9.1.2

--- a/wiki/Releases/4.9.1.md
+++ b/wiki/Releases/4.9.1.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
  * *DO NOT USE* - this is a buggy release. You'll want [4.9.1.1](4.9.1.1.html) instead!
- * [rpm-4.9.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.tar.bz2) source
+ * [rpm-4.9.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/historical/rpm-4.9.x/rpm-4.9.1.tar.bz2) source
  * SHA1SUM: c142f0de1a109a719e322e44690f060eb8cd06e8
 
 ## Summary of changes from RPM 4.9.0

--- a/wiki/Releases/4.9.1.md
+++ b/wiki/Releases/4.9.1.md
@@ -41,7 +41,7 @@ title: rpm.org - Releases
  * Pay attention to dir vs file when building ([RhBug:505995](https://bugzilla.redhat.com/show_bug.cgi?id=505995))
  * Fail build on unclosed macros & trailing line continuations in spec ([RhBug:681567](https://bugzilla.redhat.com/show_bug.cgi?id=681567))
  * Always abort build immediately on spec %prep section errors
- * Don't remove buildroot docdir on %doc usage (ticket [#836](http://rpm.org/ticket/836))
+ * Don't remove buildroot docdir on %doc usage (ticket [#836](https://rpm.org/ticket/836))
  * Support automatic unpacking of lzip and lrzip compressed sources
  * Support automatic unpacking of 'PK00' zip compressed sources ([RhBug:699529](https://bugzilla.redhat.com/show_bug.cgi?id=699529))
  * Fix find-lang to find *@*.qm QT i18n files ([RhBug:699945](https://bugzilla.redhat.com/show_bug.cgi?id=699945))
@@ -74,7 +74,7 @@ title: rpm.org - Releases
  * Give at least some indication of error from fchdir() failures
  * Handle headerGet() / pgpPrtPkts() failure on signature verify
  * Remember to free db index iterators too on forced termination
- * Fix dangling databases from iterators (ticket [#820](http://rpm.org/ticket/820))
+ * Fix dangling databases from iterators (ticket [#820](https://rpm.org/ticket/820))
  * Dont reference transaction set from transaction elements
  * Fix memleak in rpmsign tool
  * Fix memleaks in macro definition error cases
@@ -95,5 +95,5 @@ title: rpm.org - Releases
  * Compatibility with autoconf-2.68
  * Silence unused-but-set warnings on gcc >= 4.6.0
  * zlib is considered mandatory
- * Use pkg-config to find Lua + determine flags (ticket [#88](http://rpm.org/ticket/88))
+ * Use pkg-config to find Lua + determine flags (ticket [#88](https://rpm.org/ticket/88))
  * Python version compatibility fixes

--- a/wiki/Releases/4.9.1.md
+++ b/wiki/Releases/4.9.1.md
@@ -9,7 +9,7 @@ title: rpm.org - Releases
 
 ## Download information
  * *DO NOT USE* - this is a buggy release. You'll want [4.9.1.1](4.9.1.1.html) instead!
- * [rpm-4.9.1.tar.bz2](http://ftp.rpm.org/releases/rpm-4.9.x/rpm-4.9.1.tar.bz2) source
+ * [rpm-4.9.1.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/rpm-4.9.x/rpm-4.9.1.tar.bz2) source
  * SHA1SUM: c142f0de1a109a719e322e44690f060eb8cd06e8
 
 ## Summary of changes from RPM 4.9.0


### PR DESCRIPTION
Use https://ftp.osuosl.org/pub/rpm instead of ftp.rpm.org
and fix broken download links.