### PR TITLE
Add old trac tickets mentioned in the release notes

### DIFF
--- a/attachment/ticket/101/osgideps.pl_2009-08-25.patch
+++ b/attachment/ticket/101/osgideps.pl_2009-08-25.patch
@@ -1,0 +1,380 @@
+--- scripts/osgideps.pl.ori	2009-09-25 09:13:17.864681326 +0200
++++ scripts/osgideps.pl	2009-09-25 09:13:23.372682173 +0200
+@@ -2,26 +2,18 @@
+ #
+ # osgideps.pl -- Analyze dependencies of OSGi bundles.
+ #
+-# Kyu Lee
+-# Alphonse Van Assche <alcapcom@fedoraproject.org>
++# Kyu Lee (initial idea)
++# Alphonse Van Assche <alcapcom@fedoraproject.org> (current maintainer)
+ #
+ # $Id: osgideps.pl,v 1.0 2009/06/08 12:12:12 mej Exp $
+-#
+ 
+-use Cwd;
+ use Getopt::Long;
+ use File::Temp qw/ tempdir /;
++use threads;
++use Thread::Queue;
+ 
+-$cdir = getcwd();
+-$TEMPDIR = tempdir( CLEANUP => 1 );
+ $MANIFEST_NAME = "META-INF/MANIFEST.MF";
+ 
+-# prepare temporary directory
+-if ( !( -d $TEMPDIR ) ) {
+-	if ( ( $_ = `mkdir $TEMPDIR` ) != 0 ) { exit 1; }
+-	elsif ( !( -w $TEMPDIR ) && ( -x $TEMPDIR ) ) { exit 1; }
+-}
+-
+ # parse options
+ my ( $show_provides, $show_requires, $show_system_bundles, $debug );
+ my $result = GetOptions(
+@@ -47,168 +39,208 @@
+ 
+ # this function print provides of OSGi aware files
+ sub getProvides {
++	
++	my $queue = Thread::Queue->new;
+ 	foreach $file (@_) {
+-		chomp($file);
+-		# we don't follow symlinks for provides
+-		next if -f $file && -r $file && -l $file;
+-		$file =~ s/[^[:print:]]//g;
+-		if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
+-			if ( $file =~ m/\.jar$/ ) {
+-				if ( `jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
+-					# extract MANIFEST.MF file from jar to temporary directory
+-					chdir $TEMPDIR;
+-					`jar xf $file $MANIFEST_NAME`;
+-					open( MANIFEST, "$MANIFEST_NAME" );
+-					chdir $cdir;
++		$queue->enqueue($file);
++	}
++
++	my @workers;
++	push @workers, threads->create('getProvidesWorker');
++	push @workers, threads->create('getProvidesWorker');
++	push @workers, threads->create('getProvidesWorker');
++	push @workers, threads->create('getProvidesWorker');
++
++	map { $_->join } @workers;
++	
++	sub getProvidesWorker {
++		while ( my $file = $queue->dequeue_nb ) {
++			chomp($file);
++			# we don't follow symlinks for provides
++			next if ( -f $file && -r $file && -l $file );
++			$file =~ s/[^[:print:]]//g;
++			if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
++				if ( $file =~ m/\.jar$/ ) {
++					if ( `zipinfo -1 $file 2> /dev/null | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
++						# extract MANIFEST.MF file from jar to temporary directory
++						$tmpdir = tempdir( CLEANUP => 1 );						
++						`unzip -d $tmpdir -qqo $file $MANIFEST_NAME`;
++						open( MANIFEST, "$tmpdir/$MANIFEST_NAME" );
++					}
++				} else {
++					open( MANIFEST, "$file" );
+ 				}
+-			} else {
+-				open( MANIFEST, "$file" );
+-			}
+-			my $bundleName = "";
+-			my $version = "";
+-			# parse Bundle-SymbolicName, Bundle-Version and Export-Package attributes
+-			while (<MANIFEST>) {
+-				# get rid of non-print chars (some manifest files contain weird chars)
+-				s/[^[:print]]//g;
+-				if ( m/(^(Bundle-SymbolicName): )(.*)$/ ) {
+-					$bundleName = "$3" . "\n";
+-					while (<MANIFEST>) {
+-						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
+-							$len = length $_;
+-							seek MANIFEST, $len * -1, 1;
+-							last;
++				my $bundleName = "";
++				my $version = "";
++				# parse Bundle-SymbolicName, Bundle-Version and Export-Package attributes
++				while (<MANIFEST>) {
++					# get rid of non-print chars (some manifest files contain weird chars)
++					s/[^[:print]]//g;
++					if ( m/(^(Bundle-SymbolicName): )(.*)$/ ) {
++						$bundleName = "$3" . "\n";
++						while (<MANIFEST>) {
++							if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++								$len = length $_;
++								seek MANIFEST, $len * -1, 1;
++								last;
++							}
++							$bundleName .= "$_";
+ 						}
+-						$bundleName .= "$_";
++						$bundleName =~ s/\s+//g;
++						$bundleName =~ s/;.*//g;
+ 					}
+-					$bundleName =~ s/\s+//g;
+-					$bundleName =~ s/;.*//g;
+-				}
+-				if ( m/(^Bundle-Version: )(.*)/ ) {
+-					$version = $2;
+-				}
+-				if ( m/(^(Export-Package): )(.*)$/ ) {
+-					my $bunlist = "$3" . "\n";
+-					while (<MANIFEST>) {
+-						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
+-							$len = length $_;
+-							seek MANIFEST, $len * -1, 1;
+-							last;
++					if ( m/(^Bundle-Version: )(.*)/ ) {
++						$version = $2;
++					}
++					if ( m/(^(Export-Package): )(.*)$/ ) {
++						my $bunlist = "$3" . "\n";
++						while (<MANIFEST>) {
++							if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++								$len = length $_;
++								seek MANIFEST, $len * -1, 1;
++								last;
++							}
++							$bunlist .= "$_";
+ 						}
+-						$bunlist .= "$_";
++						push @bundlelist, parsePkgString($bunlist, $file);
++					}
++				}	
++	
++				# skip this jar if no bundle name exists
++				if ( !$bundleName eq "" ) {
++					if ( !$version eq "" ) {
++						$version = parseVersion($version);
++						push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "$version" };
++					} else {	
++						push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "" };
+ 					}
+-					push @bundlelist, parsePkgString($bunlist, $file);
+-				}
+-			}
+-
+-			# skip this jar if no bundle name exists
+-			if ( !$bundleName eq "" ) {
+-				if ( !$version eq "" ) {
+-					$version = parseVersion($version);
+-					push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "$version" };
+-				} else {
+-					push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "" };
+ 				}
++				`rm -rf $tmpdir`;
+ 			}
+ 		}
+-	}
+-	if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
+-	$list = "";
+-	for $bundle (@bundlelist) {
+-		if ( !$debug ) {
+-			$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
+-		} else {
+-			$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
++		$list = "";
++		for $bundle (@bundlelist) {
++			if ( !$debug ) {
++				$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++			} else {
++				$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++			}
+ 		}
++		print $list;
+ 	}
+-	print $list;
+ }
+ 
+ # this function print requires of OSGi aware files
+ sub getRequires {
++
++	my $queue = Thread::Queue->new;
+ 	foreach $file (@_) {
+-		next if (-f $file && -r $file);
+-		# we explicitly requires symlinked jars
+-		if (-l $file) {
+-			$file = readlink $file;
+-			if ( !$file eq "" ) {							
+-				print "$file" . "\n";
+-			}
+-			next;
+-		} 
+-		$file =~ s/[^[:print:]]//g;
+-		if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
+-			if ( $file =~ m/\.jar$/ ) {
+-				if ( `jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
+-					# extract MANIFEST.MF file from jar to temporary directory
+-					chdir $TEMPDIR;
+-					`jar xf $file $MANIFEST_NAME`;
+-					open( MANIFEST, "$MANIFEST_NAME" );
+-					chdir $cdir;
+-				}
+-			} else {
+-				open( MANIFEST, "$file" );
+-			}
+-			while (<MANIFEST>) {
+-				if ( m/(^(Require-Bundle|Import-Package): )(.*)$/ ) {
+-					my $bunlist = "$3" . "\n";
+-					while (<MANIFEST>) {
+-						if (m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
+-							$len = length $_;
+-							seek MANIFEST, $len * -1, 1;
++		$queue->enqueue($file);
++	}
++
++	my @workers;
++	push @workers, threads->create('getRequiresWorker');
++	push @workers, threads->create('getRequiresWorker');
++	push @workers, threads->create('getRequiresWorker');
++	push @workers, threads->create('getRequiresWorker');
++
++	map { $_->join } @workers;
++	
++	sub getRequiresWorker {
++		while ( my $file = $queue->dequeue_nb ) {
++			next if ( -f $file && -r $file );
++			$file =~ s/[^[:print:]]//g;
++			if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
++				# we explicitly requires symlinked jars
++				# _that_reside_outside_the_package_
++				if (-l $file) {
++					$exist = 0;
++					$lnksrc = `readlink -qen $file`;
++					foreach $exfile ( @allfiles ) {
++						$exfile =~ s/[^[:print:]]//g;
++						if ( $lnksrc =~ m/$exfile$/ ) {							
++							$exist = 1;
+ 							last;
+ 						}
+-						$bunlist .= "$_";
+ 					}
+-					push @bundlelist, parsePkgString($bunlist, $file);
++					print "$lnksrc\n" if (!$exist);
++					next;
++				}	 
++				
++				if ( $file =~ m/\.jar$/ ) {
++					if ( `zipinfo -1 $file 2> /dev/null | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
++						# extract MANIFEST.MF file from jar to temporary directory
++						$tmpdir = tempdir( CLEANUP => 1 );
++						`unzip -d $tmpdir -qqo $file $MANIFEST_NAME`;
++						open( MANIFEST, "$tmpdir/$MANIFEST_NAME" );
++					}
++				} else {
++					open( MANIFEST, "$file" );
+ 				}
+-				# we also explicitly require symlinked jars define by 
+-				# Bundle-ClassPath attribut
+-				if ( m/(^(Bundle-ClassPath): )(.*)$/ ) {
+-					$bunclp = "$3" . "\n";
+-					while (<MANIFEST>) {
+-						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
+-							$len = length $_;
+-							seek MANIFEST, $len * -1, 1;
+-							last;
++				while (<MANIFEST>) {
++					if ( m/(^(Require-Bundle|Import-Package): )(.*)$/ ) {
++						my $bunlist = "$3" . "\n";
++						while (<MANIFEST>) {
++							if (m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++								$len = length $_;
++								seek MANIFEST, $len * -1, 1;
++								last;
++							}
++							$bunlist .= "$_";
+ 						}
+-						$bunclp .= "$_";
++						push @bundlelist, parsePkgString($bunlist, $file);
+ 					}
+-					$bunclp =~ s/\ //g;
+-					$bunclp =~ s/\n//g;
+-					$bunclp =~ s/[^[:print:]]//g;
+-					$dir = `dirname $file`;
+-					$dir =~ s/\n//g;
+-					@jars = split /,/, $bunclp;
+-					for $jarfile (@jars) {
+-						$jarfile = "$dir\/\.\.\/$jarfile";
+-						$jarfile = readlink $jarfile;
+-						if ( !$jarfile eq "" ) {							
+-							print "$jarfile" . "\n";
++					# we also explicitly require symlinked jars define by 
++					# Bundle-ClassPath attribut
++					if ( m/(^(Bundle-ClassPath): )(.*)$/ ) {
++						$bunclp = "$3" . "\n";
++						while (<MANIFEST>) {
++							if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++								$len = length $_;
++								seek MANIFEST, $len * -1, 1;
++								last;
++							}
++							$bunclp .= "$_";
++						}
++						$bunclp =~ s/\ //g;
++						$bunclp =~ s/\n//g;
++						$bunclp =~ s/[^[:print:]]//g;
++						$dir = `dirname $file`;
++						$dir =~ s/\n//g;
++						@jars = split /,/, $bunclp;
++						for $jarfile (@jars) {
++							$jarfile = "$dir\/\.\.\/$jarfile";
++							$jarfile = readlink $jarfile;
++							if ( !$jarfile eq "" ) {							
++								print "$jarfile" . "\n";
++							}
+ 						}
+ 					}
+ 				}
++				`rm -rf $tmpdir`;
+ 			}
+ 		}
+-	}
+-	if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
+-	$list = "";
+-	for $bundle (@bundlelist) {
+-		# replace '=' by '>=' because qualifiers are set on provides 
+-		# but not on requires.
+-		$bundle->{VERSION} =~ s/\ =/\ >=/g;
+-		if ( !$debug ) {
+-			$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
+-		} else {
+-			$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
++		$list = "";
++		for $bundle (@bundlelist) {
++			# replace '=' by '>=' because qualifiers are set on provides 
++			# but not on requires.
++			$bundle->{VERSION} =~ s/\ =/\ >=/g;
++			if ( !$debug ) {
++				$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++			} else {
++				$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++			}
+ 		}
++		print $list;
+ 	}
+-	print $list;
+ }
+ 
+ # this function print system bundles of OSGi profile files.
+ sub getSystemBundles {
+ 	foreach $file (@_) {
+-		if ( -r $file && -r $file ) {
++		if ( -f $file && -r $file ) {
+ 			print "'$file' file not found or cannot be read!";
+ 			next;
+ 		} else {
+@@ -261,8 +293,7 @@
+ 		$version = "";
+ 		$name = $reqelementfrmnt[0];
+ 		$name =~ s/\"//g;
+-		# ignore 'system.bundle'.
+-		# see http://help.eclipse.org/stable/index.jsp?topic=/org.eclipse.platform.doc.isv/porting/3.3/incompatibilities.html
++		# ignoring OSGi 'system.bundle' 
+ 		next if ( $name =~ m/^system\.bundle$/ );
+ 		for $i ( 1 .. $#reqelementfrmnt ) {
+ 			if ( $reqelementfrmnt[$i] =~ m/(^(bundle-|)version=")(.*)(")/ ) {

--- a/attachment/ticket/107/fix-linkage.patch
+++ b/attachment/ticket/107/fix-linkage.patch
@@ -1,0 +1,22 @@
+Description: Fix linkage of some binaries
+ These binaries use symbols from other libraries, but do not link to them.
+ Because of this they fail to build with binutils-gold which make default
+ --no-add-needed.
+Author: Michal Čihař <nijel@debian.org>
+Forwarded: http://rpm.org/ticket/107
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -118,11 +118,11 @@
+ 
+ rpmlibexec_PROGRAMS +=	rpmdeps
+ rpmdeps_SOURCES =	tools/rpmdeps.c
+-rpmdeps_LDADD =		build/librpmbuild.la
++rpmdeps_LDADD =		lib/librpm.la rpmio/librpmio.la build/librpmbuild.la @WITH_POPT_LIB@
+ 
+ bin_PROGRAMS +=		rpmgraph
+ rpmgraph_SOURCES =	tools/rpmgraph.c
+-rpmgraph_LDADD =	lib/librpm.la
++rpmgraph_LDADD =	lib/librpm.la rpmio/librpmio.la @WITH_POPT_LIB@
+ 
+ dist_bin_SCRIPTS =	scripts/gendiff
+ 

--- a/attachment/ticket/126/0002-Document-conflicts-in-rpm-8.patch
+++ b/attachment/ticket/126/0002-Document-conflicts-in-rpm-8.patch
@@ -1,0 +1,43 @@
+From 61b145eb80c56ccc1a063c6bf650098e4546c10b Mon Sep 17 00:00:00 2001
+From: =?utf-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Sat, 23 Jan 2010 14:50:17 +0200
+Subject: [PATCH 2/2] Document --conflicts in rpm(8).
+
+---
+ doc/rpm.8 |   13 ++++++++-----
+ 1 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/doc/rpm.8 b/doc/rpm.8
+index 4e038f4..ae89d79 100644
+--- a/doc/rpm.8
++++ b/doc/rpm.8
+@@ -77,11 +77,11 @@ rpm \- RPM Package Manager
+ .PP
+ 
+ 
+- [\fB--changelog\fR] [\fB-c,--configfiles\fR] [\fB-d,--docfiles\fR] [\fB--dump\fR]
+- [\fB--filesbypkg\fR] [\fB-i,--info\fR] [\fB--last\fR] [\fB-l,--list\fR]
+- [\fB--provides\fR] [\fB--qf,--queryformat \fIQUERYFMT\fB\fR]
+- [\fB-R,--requires\fR] [\fB--scripts\fR] [\fB-s,--state\fR]
+- [\fB--triggers,--triggerscripts\fR]
++ [\fB--changelog\fR] [\fB-c,--configfiles\fR] [\fB--conflicts\fR]
++ [\fB-d,--docfiles\fR] [\fB--dump\fR] [\fB--filesbypkg\fR] [\fB-i,--info\fR]
++ [\fB--last\fR] [\fB-l,--list\fR] [\fB--provides\fR]
++ [\fB--qf,--queryformat \fIQUERYFMT\fB\fR] [\fB-R,--requires\fR]
++ [\fB--scripts\fR] [\fB-s,--state\fR] [\fB--triggers,--triggerscripts\fR]
+ 
+ .SS "verify-options"
+ .PP
+@@ -590,6 +590,9 @@ Display change information for the package.
+ \fB-c, --configfiles\fR
+ List only configuration files (implies \fB-l\fR).
+ .TP
++\fB--conflicts\fR
++List capabilities this package conflicts with.
++.TP
+ \fB-d, --docfiles\fR
+ List only documentation files (implies \fB-l\fR).
+ .TP
+-- 
+1.6.2.5
+

--- a/attachment/ticket/128/0002-More-here-doc-skipping-fixes-for-perl.req-128.patch
+++ b/attachment/ticket/128/0002-More-here-doc-skipping-fixes-for-perl.req-128.patch
@@ -1,0 +1,27 @@
+From b411f85d7cccae357aec4cd688a3a0f8cb606aa7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Wed, 3 Mar 2010 20:49:42 +0200
+Subject: [PATCH 2/2] More here-doc skipping fixes for perl.req (#128).
+
+---
+ scripts/perl.req |    4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/perl.req b/scripts/perl.req
+index ab21b08..1b7286a 100755
+--- a/scripts/perl.req
++++ b/scripts/perl.req
+@@ -104,8 +104,8 @@ sub process_file {
+ 
+     # skip the "= <<" block
+ 
+-    if (m/^\s*\$(?:.*)\s*=\s*<<\s*(["'`])(.*)\1/ ||
+-        m/^\s*\$(.*)\s*=\s*<<(\w*)\s*;/) {
++    if (m/^\s*\$(?:.*)\s*=\s*<<\s*(["'`])(.+?)\1/ ||
++        m/^\s*\$(.*)\s*=\s*<<(\w+)\s*;/) {
+       $tag = $2;
+       while (<FILE>) {
+         chomp;
+-- 
+1.6.6.1
+

--- a/attachment/ticket/128/0004-perl.-req-prov-whitespace-backslash-and-paren-clea.patch
+++ b/attachment/ticket/128/0004-perl.-req-prov-whitespace-backslash-and-paren-clea.patch
@@ -1,0 +1,319 @@
+From b4b75405b24bd28d96fb0db857900f86a79a1d57 Mon Sep 17 00:00:00 2001
+From: =?utf-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Sun, 24 Jan 2010 13:42:46 +0200
+Subject: [PATCH 4/4] perl.{req,prov} whitespace, backslash and paren cleanups.
+
+---
+ scripts/perl.prov |   50 +++++++++++++++++++-------------------
+ scripts/perl.req  |   68 ++++++++++++++++++++++++++--------------------------
+ 2 files changed, 59 insertions(+), 59 deletions(-)
+
+diff --git a/scripts/perl.prov b/scripts/perl.prov
+index 103488c..4d5bd81 100755
+--- a/scripts/perl.prov
++++ b/scripts/perl.prov
+@@ -81,13 +81,13 @@ sub process_file {
+ 
+   my ($file) = @_;
+   chomp $file;
+-  
++
+   open(FILE, "<$file") || return;
+ 
+   my ($package, $version, $incomment, $inover) = ();
+ 
+   while (<FILE>) {
+-    
++
+     # skip the documentation
+ 
+     # we should not need to have item in this if statement (it
+@@ -102,7 +102,7 @@ sub process_file {
+       $incomment = 0;
+       $inover = 0;
+     }
+-    
++
+     if (m/^=(over)/) {
+       $inover = 1;
+     }
+@@ -114,7 +114,7 @@ sub process_file {
+     if ($incomment || $inover) {
+        next;
+     }
+-    
++
+     # skip the data section
+     if (m/^__(DATA|END)__$/) {
+       last;
+@@ -125,7 +125,7 @@ sub process_file {
+     # false positives as if they were provided packages (really ugly).
+ 
+     if (m/^\s*package\s+([_:a-zA-Z0-9]+)\s*;/) {
+-      $package=$1;
++      $package = $1;
+       undef $version;
+       if ($package eq 'main') {
+         undef $package;
+@@ -134,7 +134,7 @@ sub process_file {
+         # the package definition is broken up over multiple blocks.
+         # In that case, don't stomp a previous $VERSION we might have
+         # found.  (See BZ#214496.)
+-        $require{$package}=undef unless (exists $require{$package});
++        $require{$package} = undef unless (exists $require{$package});
+       }
+     }
+ 
+@@ -149,44 +149,44 @@ sub process_file {
+     #CGI/Apache.pm:$VERSION = (qw$Revision: 1.9 $)[1];
+     #DynaLoader.pm:$VERSION = $VERSION = "1.03";     # avoid typo warning
+     #General.pm:$Config::General::VERSION = 2.33;
+-    # 
++    #
+     # or with the new "our" pragma you could (read will) see:
+     #
+     #    our $VERSION = '1.00'
+-    if (($package) && (m/^\s*(our\s+)?\$(\Q$package\E::)?VERSION\s*=\s+/)) {
++    if ($package && m/^\s*(our\s+)?\$(\Q$package\E::)?VERSION\s*=\s+/) {
+ 
+       # first see if the version string contains the string
+       # '$Revision' this often causes bizzare strings and is the most
+       # common method of non static numbering.
+ 
+       if (m/(\$Revision: (\d+[.0-9]+))/) {
+-	$version= $2; 
+-      } elsif (m/[\'\"]?(\d+[.0-9]+)[\'\"]?/) {
+-	
+-	# look for a static number hard coded in the script
+-	
+-	$version= $1; 
++        $version = $2;
++      } elsif (m/['"]?(\d+[.0-9]+)['"]?/) {
++
++        # look for a static number hard coded in the script
++
++        $version = $1;
+       }
+-      $require{$package}=$version;
++      $require{$package} = $version;
+     }
+-  
++
+     # Allow someone to have a variable that defines virtual packages
+-    # The variable is called $RPM_Provides.  It must be scoped with 
+-    # "our", but not "local" or "my" (just would not make sense). 
+-    # 
++    # The variable is called $RPM_Provides.  It must be scoped with
++    # "our", but not "local" or "my" (just would not make sense).
++    #
+     # For instance:
+-    #  
++    #
+     #     $RPM_Provides = "blah bleah"
+-    # 
++    #
+     # Will generate provides for "blah" and "bleah".
+     #
+     # Each keyword can appear multiple times.  Don't
+     #  bother with datastructures to store these strings,
+     #  if we need to print it print it now.
+-	
+-    if ( m/^\s*(our\s+)?\$RPM_Provides\s*=\s*["'](.*)['"]/i) {
++
++    if (m/^\s*(our\s+)?\$RPM_Provides\s*=\s*["'](.*)['"]/i) {
+       foreach $_ (split(/\s+/, $2)) {
+-	print "$_\n";
++        print "$_\n";
+       }
+     }
+ 
+@@ -195,5 +195,5 @@ sub process_file {
+   close(FILE) ||
+     die("$0: Could not close file: '$file' : $!\n");
+ 
+-  return ;
++  return;
+ }
+diff --git a/scripts/perl.req b/scripts/perl.req
+index 28ff782..9d609fa 100755
+--- a/scripts/perl.req
++++ b/scripts/perl.req
+@@ -1,6 +1,6 @@
+ #!/usr/bin/perl
+ 
+-# RPM (and its source code) is covered under two separate licenses. 
++# RPM (and its source code) is covered under two separate licenses.
+ 
+ # The entire code base may be distributed under the terms of the GNU
+ # General Public License (GPL), which appears immediately below.
+@@ -18,7 +18,7 @@
+ # Erik Troan <ewt@redhat.com>.
+ 
+ # a simple makedepend like script for perl.
+- 
++
+ # To save development time I do not parse the perl grammmar but
+ # instead just lex it looking for what I want.  I take special care to
+ # ignore comments and pod's.
+@@ -44,10 +44,10 @@ if ("@ARGV") {
+     process_file($_);
+   }
+ } else {
+-  
++
+   # notice we are passed a list of filenames NOT as common in unix the
+   # contents of the file.
+-  
++
+   foreach (<>) {
+     process_file($_);
+   }
+@@ -72,18 +72,18 @@ exit 0;
+ 
+ 
+ sub process_file {
+-  
++
+   my ($file) = @_;
+   chomp $file;
+-  
++
+   open(FILE, "<$file") || return;
+-  
++
+   while (<FILE>) {
+-    
++
+     # skip the "= <<" block
+ 
+-    if ( ( m/^\s*\$(?:.*)\s*=\s*<<\s*(["'`])(.*)\1/) ||
+-         ( m/^\s*\$(.*)\s*=\s*<<(\w*)\s*;/) ) {
++    if (m/^\s*\$(?:.*)\s*=\s*<<\s*(["'`])(.*)\1/ ||
++        m/^\s*\$(.*)\s*=\s*<<(\w*)\s*;/) {
+       $tag = $2;
+       while (<FILE>) {
+         chomp;
+@@ -95,7 +95,7 @@ sub process_file {
+     # skip q{} quoted sections - just hope we don't have curly brackets
+     # within the quote, nor an escaped hash mark that isn't a comment
+     # marker, such as occurs right here. Draw the line somewhere.
+-    if ( m/^.*\Wq[qxwr]?\s*([\{\(\[#|\/])[^})\]#|\/]*$/ && ! m/^\s*(require|use)\s/ ) {
++    if ( m/^.*\Wq[qxwr]?\s*([{([#|\/])[^})\]#|\/]*$/ && ! m/^\s*(require|use)\s/ ) {
+       $tag = $1;
+       $tag =~ tr/{\(\[\#|\//})]#|\//;
+       while (<FILE>) {
+@@ -116,7 +116,7 @@ sub process_file {
+     if ( (m/^=(over)/) .. (m/^=(back)/) ) {
+       next;
+     }
+-    
++
+     # skip the data section
+     if (m/^__(DATA|END)__$/) {
+       last;
+@@ -126,14 +126,14 @@ sub process_file {
+     #  bother with datastructures to store these strings,
+     #  if we need to print it print it now.
+     #
+-	# Again allow for "our".
+-    if ( m/^\s*(our\s+)?\$RPM_Requires\s*=\s*["'](.*)['"]/i) {
++        # Again allow for "our".
++    if (m/^\s*(our\s+)?\$RPM_Requires\s*=\s*["'](.*)['"]/i) {
+       foreach $_ (split(/\s+/, $2)) {
+-	print "$_\n";
++        print "$_\n";
+       }
+     }
+ 
+-    if ( 
++    if (
+ 
+ # ouch could be in a eval, perhaps we do not want these since we catch
+ # an exception they must not be required
+@@ -143,13 +143,13 @@ sub process_file {
+ #   eval { require Carp } if defined $^S; # If error/warning during compilation,
+ 
+ 
+-	(m/^(\s*)         # we hope the inclusion starts the line
+-	 (require|use)\s+(?!\{)     # do not want 'do {' loops
+-	 # quotes around name are always legal
+-	 [\'\"]?([^\;\ \'\"\t#]*)[\'\"]?[\t\;\ ]
+-	 # the syntax for 'use' allows version requirements
+-	 \s*([.0-9]*)
+-	 /x)
++        (m/^(\s*)         # we hope the inclusion starts the line
++         (require|use)\s+(?!\{)     # do not want 'do {' loops
++         # quotes around name are always legal
++         ['"]?([^; '"\t#]*)['"]?[\t; ]
++         # the syntax for 'use' allows version requirements
++         \s*([.0-9]*)
++         /x)
+        ) {
+       my ($whitespace, $statement, $module, $version) = ($1, $2, $3,$4);
+ 
+@@ -163,7 +163,7 @@ sub process_file {
+       # if there is some interpolation of variables just skip this
+       # dependency, we do not want
+       #        do "$ENV{LOGDIR}/$rcfile";
+-   
++
+       ($module =~ m/\$/) && next;
+ 
+       # skip if the phrase was "use of" -- shows up in gimp-perl, et al.
+@@ -195,7 +195,7 @@ sub process_file {
+ 
+       $module =~ s/\.pm$//;
+ 
+-      # some perl programmers write 'require URI/URL;' when 
++      # some perl programmers write 'require URI/URL;' when
+       # they mean 'require URI::URL;'
+ 
+       $module =~ s/\//::/;
+@@ -209,7 +209,7 @@ sub process_file {
+       # if module is a number then both require and use interpret that
+       # to mean that a particular version of perl is specified
+ 
+-      my $ver=$1;
++      my $ver = $1;
+       if ($ver =~ /5.00/) {
+         print "perl >= 0:$ver\n";
+         next;
+@@ -223,10 +223,10 @@ sub process_file {
+ 
+       # ph files do not use the package name inside the file.
+       # perlmodlib documentation says:
+-      
++
+       #       the .ph files made by h2ph will probably end up as
+       #       extension modules made by h2xs.
+-      
++
+       # so do not expend much effort on these.
+ 
+ 
+@@ -234,16 +234,16 @@ sub process_file {
+       # will be included with the name sys/systeminfo.ph so only use the
+       # basename of *.ph files
+ 
+-      ($module  =~ m/\.ph$/) && next;
++      ($module =~ m/\.ph$/) && next;
+ 
+-      $require{$module}=$version;
+-      $line{$module}=$_;
++      $require{$module} = $version;
++      $line{$module} = $_;
+     }
+-    
++
+   }
+ 
+   close(FILE) ||
+     die("$0: Could not close file: '$file' : $!\n");
+-  
+-  return ; 
++
++  return;
+ }
+-- 
+1.6.2.5
+

--- a/attachment/ticket/136/0008-Extract-interpreter-dependencies-from-usr-bin-env-sc.patch
+++ b/attachment/ticket/136/0008-Extract-interpreter-dependencies-from-usr-bin-env-sc.patch
@@ -1,0 +1,39 @@
+From ab02d04ccebfebf9b0c01056a730a97cdce24eb9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Wed, 10 Feb 2010 22:45:54 +0200
+Subject: [PATCH 8/8] Extract interpreter dependencies from #!/usr/bin/env scripts.
+
+---
+ scripts/interpreter.req |   17 ++++++++++++++++-
+ 1 files changed, 16 insertions(+), 1 deletions(-)
+
+diff --git a/scripts/interpreter.req b/scripts/interpreter.req
+index 215bd50..1e7dd6a 100755
+--- a/scripts/interpreter.req
++++ b/scripts/interpreter.req
+@@ -1,6 +1,21 @@
+ #!/bin/sh
+ 
+-# TODO: handle #!/usr/bin/env somehow
++# "rpm managed" dirs in system default path
++defpaths="/bin /usr/bin"
++
+ while read filename; do
++    # common cases
+     sed -n -e '1s:^#![[:space:]]*\(/[^[:space:]]\{1,\}\).*:\1:p' "$filename"
++    #!/usr/bin/env /foo/bar
++    sed -n -e '1s:^#![[:space:]]*[^[:space:]]*/bin/env[[:space:]]\{1,\}\(/[^[:space:]]\{1,\}\):\1:p' "$filename"
++    #!/usr/bin/env foo -> look in default paths
++    sed -n -e '1s:^#![[:space:]]*[^[:space:]]*/bin/env[[:space:]]\{1,\}\([^/[:space:]]\{1,\}\)[[:space:]]*$:\1:p' "$filename" \
++        | while read interpreter; do
++        for path in $defpaths; do
++            if [ -x $path/$interpreter ]; then
++                echo $path/$interpreter
++                break
++            fi
++        done
++    done
+ done
+-- 
+1.6.6
+

--- a/attachment/ticket/137/80_relative-tarball.patch
+++ b/attachment/ticket/137/80_relative-tarball.patch
@@ -1,0 +1,11 @@
+--- a/build.c	2009-04-03 07:38:40.000000000 -0400
++++ b/build.c	2010-02-11 09:43:12.809240587 -0500
+@@ -218,7 +218,7 @@
+     if (*specFile != '/') {
+ 	char *cwd = rpmGetCwd();
+ 	char *s = NULL;
+-	rasprintf(&s, "%s/%s", cwd, arg);
++	rasprintf(&s, "%s/%s", cwd, specFile);
+ 	free(cwd);
+ 	free(specFile);
+ 	specFile = s;

--- a/attachment/ticket/14/rpm-4.6.0-python-spec-headers.patch
+++ b/attachment/ticket/14/rpm-4.6.0-python-spec-headers.patch
@@ -1,0 +1,75 @@
+Index: rpm-4.6.0-rc1/python/spec-py.c
+===================================================================
+--- rpm-4.6.0-rc1.orig/python/spec-py.c
++++ rpm-4.6.0-rc1/python/spec-py.c
+@@ -5,6 +5,7 @@
+ #include "system.h"
+ 
+ #include "spec-py.h"
++#include "header-py.h"
+ 
+ /** \ingroup python
+  * \name Class: Rpmspec
+@@ -147,6 +148,53 @@ spec_get_sources(specObject *s)
+ 
+ }
+ 
++static PyObject *
++spec_get_sourceHeader(specObject *s)
++{
++    rpmSpec spec;
++
++    spec = specFromSpec(s);
++    if (spec == NULL) {
++        return NULL;
++    }
++    if (!spec->sourceHeader) {
++        initSourceHeader(spec);
++    }
++    return (PyObject *) hdr_Wrap(spec->sourceHeader);
++}
++
++static PyObject *
++spec_get_packageHeaders(specObject *s)
++{
++    rpmSpec spec;
++    PyObject *obj;
++    Package p;
++    int n;
++    char *srcname;
++
++    spec = specFromSpec(s);
++    if (spec == NULL) {
++        return NULL;
++    }
++    for (p = spec->packages, n = 0; p; p = p->next, n++) {}
++    obj = PyList_New(n);
++    if (obj == NULL) {
++        return NULL;
++    }
++    if (!spec->sourceHeader) {
++        initSourceHeader(spec);
++    }
++    srcname = headerFormat(
++          spec->sourceHeader,
++          spec->noSource ? "%{name}-%{version}-%{release}.nosrc.rpm"
++          : "%{name}-%{version}-%{release}.src.rpm", NULL);
++    for (p = spec->packages, n = 0; p; p = p->next, n++) {
++        headerPutString(p->header, RPMTAG_SOURCERPM, srcname);
++        PyList_SET_ITEM(obj, n, (PyObject *) hdr_Wrap(p->header));
++    }
++    return obj;
++}
++
+ /**
+  */
+ 
+@@ -159,6 +207,8 @@ static PyMethodDef spec_Spec_methods[] =
+     {"install",   (PyCFunction) spec_get_install, METH_VARARGS,  NULL },
+     {"clean",   (PyCFunction) spec_get_clean, METH_VARARGS,  NULL },
+     {"buildRoot",   (PyCFunction) spec_get_buildroot, METH_VARARGS,  NULL },
++    {"sourceHeader",   (PyCFunction) spec_get_sourceHeader, METH_VARARGS,  NULL },
++    {"packageHeaders",   (PyCFunction) spec_get_packageHeaders, METH_VARARGS,  NULL },
+     {NULL}  /* Sentinel */
+ };
+ 

--- a/attachment/ticket/150/0001-Don-t-process-desktop-files-without-Type-Application.patch
+++ b/attachment/ticket/150/0001-Don-t-process-desktop-files-without-Type-Application.patch
@@ -1,0 +1,34 @@
+From 7adf30794954c8ac8d7862d35af674faef1ed155 Mon Sep 17 00:00:00 2001
+From: Pavol Rusnak <stick@gk2.sk>
+Date: Wed, 17 Mar 2010 16:02:46 +0100
+Subject: [PATCH] Don't process desktop files without Type=Application and Exec= line
+
+---
+ scripts/desktop-file.prov |   10 ++++++----
+ 1 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/scripts/desktop-file.prov b/scripts/desktop-file.prov
+index abb79f9..5b159ae 100755
+--- a/scripts/desktop-file.prov
++++ b/scripts/desktop-file.prov
+@@ -9,11 +9,13 @@ OLD_IFS="$IFS"
+ while read instfile ; do
+ 	case "$instfile" in
+ 	*.desktop)
+-		mime=`cat "$instfile" | grep MimeType= | cut -d'=' -f2`
+-                IFS=';'
++		if ! grep -q '^Type=Application$' "$instfile"; then continue; fi
++		if ! grep -q '^Exec=' "$instfile"; then continue; fi
++		mime=`grep '^MimeType=' "$instfile" | cut -d'=' -f2`
++		IFS=';'
+ 		for type in $mime ; do
+-		        echo 'mimehandler('$type')'
+-	        done
++			echo 'mimehandler('$type')'
++		done
+ 		;;
+ 	esac
+ done
+-- 
+1.6.4.2
+

--- a/attachment/ticket/150/rpm.patch
+++ b/attachment/ticket/150/rpm.patch
@@ -1,0 +1,21 @@
+--- rpm/mimetypes.prov.sav	2009-10-24 05:23:07.000000000 +0200
++++ rpm/mimetypes.prov	2010-03-17 15:33:57.437352306 +0100
+@@ -6,11 +6,13 @@ OLD_IFS="$IFS"
+ while read instfile ; do
+     case "$instfile" in
+     *.desktop)
+-        mime=$(sed -re '/^MimeType *= *([a-zA-Z0-9. _/;-]*)/!d' $instfile | cut -d'=' -f2)
+-        IFS=';'
+-        for type in $mime ; do
+-            echo 'mimetype('$type')'
+-        done
++        if grep '^Type *= *Application' "$instfile" >/dev/null 2>/dev/null; then
++            mime=$(sed -re '/^MimeType *= *([a-zA-Z0-9. _/;-]*)/!d' $instfile | cut -d'=' -f2)
++            IFS=';'
++            for type in $mime ; do
++                echo 'mimetype('$type')'
++            done
++        fi
+         ;;
+     esac
+ done

--- a/attachment/ticket/152/0003-Document-deprecation-of-mi.count-and-ds.Count.patch
+++ b/attachment/ticket/152/0003-Document-deprecation-of-mi.count-and-ds.Count.patch
@@ -1,0 +1,39 @@
+From 8d61118d0dab422f4cdd4a71a09b18886ff0afec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Fri, 19 Mar 2010 20:09:15 +0200
+Subject: [PATCH 3/3] Document deprecation of mi.count() and ds.Count().
+
+---
+ python/rpmds-py.c |    2 +-
+ python/rpmmi-py.c |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/rpmds-py.c b/python/rpmds-py.c
+index ac1b6b1..49a02e4 100644
+--- a/python/rpmds-py.c
++++ b/python/rpmds-py.c
+@@ -196,7 +196,7 @@ static PyObject * rpmds_Rpmlib(rpmdsObject * s)
+ 
+ static struct PyMethodDef rpmds_methods[] = {
+  {"Count",	(PyCFunction)rpmds_Count,	METH_NOARGS,
+-	"ds.Count -> Count	- Return no. of elements.\n" },
++	"Deprecated, use len(ds) instead.\n" },
+  {"Ix",		(PyCFunction)rpmds_Ix,		METH_NOARGS,
+ 	"ds.Ix -> Ix		- Return current element index.\n" },
+  {"DNEVR",	(PyCFunction)rpmds_DNEVR,	METH_NOARGS,
+diff --git a/python/rpmmi-py.c b/python/rpmmi-py.c
+index f6dd802..df54997 100644
+--- a/python/rpmmi-py.c
++++ b/python/rpmmi-py.c
+@@ -118,7 +118,7 @@ static struct PyMethodDef rpmmi_methods[] = {
+     {"instance",    (PyCFunction) rpmmi_Instance,	METH_NOARGS,
+ 	NULL },
+     {"count",       (PyCFunction) rpmmi_Count,		METH_NOARGS,
+-	NULL },
++"Deprecated, use len(mi) instead.\n" },
+     {"pattern",	    (PyCFunction) rpmmi_Pattern,	METH_VARARGS|METH_KEYWORDS,
+ "mi.pattern(TagN, mire_type, pattern)\n\
+ - Set a secondary match pattern on tags from retrieved header.\n" },
+-- 
+1.7.0.1
+

--- a/attachment/ticket/157/strace.log
+++ b/attachment/ticket/157/strace.log
@@ -1,0 +1,1398 @@
+execve("/bin/rpm", ["rpm", "--root", "/", "-ihv", "ts-0-0.x86_64.rpm"], ["GREP_COLOR=36;7", "LESSKEY=/etc/lesskey.bin", "NNTPSERVER=news", "MANPATH=/usr/share/man:/usr/loca"..., "HOSTNAME=borg", "XKEYSYMDB=/usr/share/X11/XKeysym"..., "HOST=borg", "TERM=screen.linux", "SHELL=/bin/bash", "PROFILEREAD=true", "HISTSIZE=1000", "PS1_XROOT=\\[\\e[1;30m\\]\\A \\[\\e[0;"..., "MORE=-sl", "JRE_HOME=/usr//jvm/jre", "USER=root", "LS_COLORS=no=0:fi=0:di=1;34:ln=1"..., "SUDO_USER=jengelh", "XNLSPATH=/usr/share/X11/nls", "SUDO_UID=25121", "ENV=/etc/bash.bashrc", "HOSTTYPE=x86_64", "FROM_HEADER=", "USERNAME=root", "PAGER=less", "CSHEDIT=emacs", "XDG_CONFIG_DIRS=/etc/xdg", "MINICOM=-c on", "MAIL=/var/spool/mail/root", "PATH=/root/bin:/usr/local/bin:/u"..., "CPU=x86_64", "NXDIR=/usr/NX", "JAVA_BINDIR=/usr/lib64/jvm/java/"..., "INPUTRC=/etc/inputrc", "PWD=/home/jengelh/lbuild/input/t"..., "JAVA_HOME=/usr/lib64/jvm/java", "EDITOR=/usr/bin/joe", "PCREGREP_COLOR=36;7", "LANG=POSIX", "PYTHONSTARTUP=/etc/pythonstart", "PS1_USER=\\A \\h:$(hxpref_beautify"..., "SDK_HOME=/usr/lib64/jvm/java", "PS1_ROOT=\\A \\h:$(hxpref_beautify"..., "PS1=\\[\\e[1;30m\\]\\A \\[\\e[0;31m\\]\\"..., "QT_SYSTEM_DIR=/usr/share/desktop"..., "JDK_HOME=/usr/lib64/jvm/java", "HOME=/root", "SUDO_COMMAND=/bin/bash -c export"..., "SHLVL=1", "LESS_ADVANCED_PREPROCESSOR=no", "OSTYPE=linux", "LS_OPTIONS=-NT0 --color=auto --g"..., "XCURSOR_THEME=DMZ", "WINDOWMANAGER=/usr/bin/twm", "LESS=-Mi", "MACHTYPE=x86_64-suse-linux", "LOGNAME=root", "CVS_RSH=ssh", "XDG_DATA_DIRS=/usr/share", "LC_CTYPE=en_US.UTF-8", "LESSOPEN=lessopen.sh %s", "SUDO_GID=100", "DISPLAY=", "PS1_XUSER=\\[\\e[1;30m\\]\\A \\[\\e[0;"..., "LESSCLOSE=lessclose.sh %s %s", "G_BROKEN_FILENAMES=1", "JAVA_ROOT=/usr/lib64/jvm/java", "COLORTERM=1", "XAUTHORITY=/home/jengelh/.Xautho"..., "mc=() {  . /usr/share/mc/bin/mc-"..., "_=/usr/bin/strace"]) = 0
+brk(0)                                  = 0x213f000
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d1300b000
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d1300a000
+access("/etc/ld.so.preload", R_OK)      = -1 ENOENT (No such file or directory)
+open("/etc/ld.so.cache", O_RDONLY)      = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1358789597, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=184, st_size=91207, st_atime=2010/05/18-08:18:01, st_mtime=2010/05/15-08:17:29, st_ctime=2010/05/15-08:17:29}) = 0
+mmap(NULL, 91207, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f6d12ff3000
+close(3)                                = 0
+open("/usr/lib64/librpm.so.0", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340\352\2\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=3507119746, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=2800, st_size=1431200, st_atime=2010/05/18-14:22:05, st_mtime=2009/11/23-20:58:57, st_ctime=2009/11/25-00:27:56}) = 0
+mmap(NULL, 3530696, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d12a91000
+fadvise64(3, 0, 3530696, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d12be6000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d12de5000, 36864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x154000) = 0x7f6d12de5000
+mmap(0x7f6d12dee000, 4040, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d12dee000
+close(3)                                = 0
+open("/usr/lib64/librpmio.so.0", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220\3\1\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=3507167206, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=656, st_size=334344, st_atime=2010/05/18-14:22:05, st_mtime=2009/11/23-20:58:57, st_ctime=2009/11/25-00:27:56}) = 0
+mmap(NULL, 2441448, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d1283c000
+fadvise64(3, 0, 2441448, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d12888000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d12a88000, 24576, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x4c000) = 0x7f6d12a88000
+mmap(0x7f6d12a8e000, 8424, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d12a8e000
+close(3)                                = 0
+open("/lib64/libpopt.so.0", O_RDONLY)   = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\300\35\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159089925, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=80, st_size=39992, st_atime=2010/05/18-14:18:01, st_mtime=2009/10/24-02:21:10, st_ctime=2009/11/10-20:46:02}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ff2000
+mmap(NULL, 2135088, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d12632000
+fadvise64(3, 0, 2135088, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d1263a000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d1283a000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x8000) = 0x7f6d1283a000
+close(3)                                = 0
+open("/lib64/libpthread.so.0", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\360X\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159090032, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=264, st_size=131260, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:20, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2208640, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d12416000
+fadvise64(3, 0, 2208640, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d1242c000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d1262c000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x16000) = 0x7f6d1262c000
+mmap(0x7f6d1262e000, 13184, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d1262e000
+close(3)                                = 0
+open("/lib64/libc.so.6", O_RDONLY)      = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220\353\1\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159130462, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=2752, st_size=1408560, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:17, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 3516488, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d120bb000
+fadvise64(3, 0, 3516488, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d1220c000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d1240c000, 20480, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x151000) = 0x7f6d1240c000
+mmap(0x7f6d12411000, 18504, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d12411000
+close(3)                                = 0
+open("/usr/lib64/liblua.so.5.1", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0\243\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=3507172491, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=384, st_size=193112, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/24-06:05:14, st_ctime=2009/11/15-20:26:22}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ff1000
+mmap(NULL, 2288136, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11e8c000
+fadvise64(3, 0, 2288136, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11eb9000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d120b8000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x2c000) = 0x7f6d120b8000
+close(3)                                = 0
+open("/lib64/libselinux.so.1", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340]\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159090045, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=232, st_size=118048, st_atime=2010/05/18-04:30:01, st_mtime=2009/10/24-02:19:25, st_ctime=2009/11/15-10:15:45}) = 0
+mmap(NULL, 2217720, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11c6e000
+fadvise64(3, 0, 2217720, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11c8a000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d11e89000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x1b000) = 0x7f6d11e89000
+mmap(0x7f6d11e8b000, 1784, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d11e8b000
+close(3)                                = 0
+open("/lib64/libbz2.so.1", O_RDONLY)    = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0\30\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159089881, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=128, st_size=62912, st_atime=2010/05/18-09:31:03, st_mtime=2009/10/24-03:20:07, st_ctime=2009/11/15-10:18:55}) = 0
+mmap(NULL, 2157936, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11a5f000
+fadvise64(3, 0, 2157936, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11a6d000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d11c6c000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0xd000) = 0x7f6d11c6c000
+close(3)                                = 0
+open("/lib64/libz.so.1", O_RDONLY)      = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\20\36\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2157845540, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=176, st_size=88640, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/24-02:05:52, st_ctime=2009/11/15-21:48:54}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ff0000
+mmap(NULL, 2183664, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11849000
+fadvise64(3, 0, 2183664, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d1185d000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d11a5d000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x14000) = 0x7f6d11a5d000
+close(3)                                = 0
+open("/usr/lib64/libelf.so.1", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\0/\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=3507142023, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=160, st_size=80448, st_atime=2010/05/17-22:24:32, st_mtime=2009/10/24-03:29:50, st_ctime=2009/11/15-10:18:34}) = 0
+mmap(NULL, 2175328, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11635000
+fadvise64(3, 0, 2175328, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11648000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d11847000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x12000) = 0x7f6d11847000
+close(3)                                = 0
+open("/lib64/liblzma.so.0", O_RDONLY)   = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0000)\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2157310041, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=264, st_size=133640, st_atime=2010/05/18-09:31:03, st_mtime=2009/10/24-02:22:33, st_ctime=2009/11/15-21:00:00}) = 0
+mmap(NULL, 2228664, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d11414000
+fadvise64(3, 0, 2228664, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11434000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d11633000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x1f000) = 0x7f6d11633000
+close(3)                                = 0
+open("/lib64/libm.so.6", O_RDONLY)      = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0`>\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159132320, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=680, st_size=346560, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:18, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12fef000
+mmap(NULL, 2441400, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d111bf000
+fadvise64(3, 0, 2441400, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d11213000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d11412000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x53000) = 0x7f6d11412000
+close(3)                                = 0
+open("/lib64/libdl.so.2", O_RDONLY)     = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\360\r\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159131917, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=32, st_size=14872, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:18, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2109696, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d10fbb000
+fadvise64(3, 0, 2109696, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d10fbd000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d111bd000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0x2000) = 0x7f6d111bd000
+close(3)                                = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12fee000
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12fed000
+arch_prctl(ARCH_SET_FS, 0x7f6d12fed790) = 0
+mprotect(0x7f6d111bd000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11412000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11633000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11847000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11a5d000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11c6c000, 4096, PROT_READ) = 0
+mprotect(0x7f6d11e89000, 4096, PROT_READ) = 0
+mprotect(0x7f6d120b8000, 8192, PROT_READ) = 0
+mprotect(0x7f6d1240c000, 16384, PROT_READ) = 0
+mprotect(0x7f6d1262c000, 4096, PROT_READ) = 0
+mprotect(0x7f6d1283a000, 4096, PROT_READ) = 0
+mprotect(0x7f6d12a88000, 8192, PROT_READ) = 0
+mprotect(0x7f6d12de5000, 20480, PROT_READ) = 0
+mprotect(0x614000, 4096, PROT_READ)     = 0
+mprotect(0x7f6d1300c000, 4096, PROT_READ) = 0
+munmap(0x7f6d12ff3000, 91207)           = 0
+set_tid_address(0x7f6d12fed860)         = 8885
+set_robust_list(0x7f6d12fed870, 0x18)   = 0
+futex(0x7fffc04769fc, FUTEX_WAKE_PRIVATE, 1) = 0
+futex(0x7fffc04769fc, 0x189 /* FUTEX_??? */, 1, NULL, 7f6d12fed790) = -1 EAGAIN (Resource temporarily unavailable)
+rt_sigaction(SIGRTMIN, {0x7f6d1241b780, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigaction(SIGRT_1, {0x7f6d1241b810, [], SA_RESTORER|SA_RESTART|SA_SIGINFO, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigprocmask(SIG_UNBLOCK, [RTMIN RT_1], NULL, 8) = 0
+getrlimit(RLIMIT_STACK, {rlim_cur=8192*1024, rlim_max=RLIM_INFINITY}) = 0
+brk(0)                                  = 0x213f000
+brk(0x2160000)                          = 0x2160000
+open("/etc/selinux/config", O_RDONLY)   = -1 ENOENT (No such file or directory)
+statfs("/selinux", {f_type=0x58465342, f_bsize=4096, f_blocks=365698971, f_bfree=188677221, f_bavail=188677221, f_files=292585344, f_ffree=291625617, f_fsid={2307, 0}, f_namelen=255, f_frsize=4096}) = 0
+open("/proc/mounts", O_RDONLY)          = 3
+fstat(3, {st_dev=makedev(0, 3), st_ino=17313828, st_mode=S_IFREG|0444, st_nlink=1, st_uid=0, st_gid=0, st_blksize=1024, st_blocks=0, st_size=0, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:19, st_ctime=2010/05/18-14:30:19}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13009000
+read(3, "rootfs / rootfs rw 0 0\nudev /dev"..., 1024) = 1024
+read(3, "itory/sles11/x86/sdk2 iso9660 ro"..., 1024) = 711
+read(3, "", 1024)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13009000, 4096)            = 0
+open("/usr/lib/locale/locale-archive", O_RDONLY) = -1 ENOENT (No such file or directory)
+open("/usr/share/locale/locale.alias", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=3235892744, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2512, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:32:57, st_ctime=2010/02/16-21:30:13}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13009000
+read(3, "# Locale name alias data base.\n#"..., 4096) = 2512
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13009000, 4096)            = 0
+open("/usr/lib/locale/en_US.UTF-8/LC_CTYPE", O_RDONLY) = -1 ENOENT (No such file or directory)
+open("/usr/lib/locale/en_US.utf8/LC_CTYPE", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1143512464, st_mode=S_IFREG|0644, st_nlink=175, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=504, st_size=256316, st_atime=2010/05/18-09:31:03, st_mtime=2010/01/27-12:33:42, st_ctime=2010/02/16-21:30:57}) = 0
+mmap(NULL, 256316, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f6d12fae000
+close(3)                                = 0
+open("/usr/lib64/gconv/gconv-modules.cache", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=2699002489, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=56, st_size=26050, st_atime=2010/05/18-04:20:01, st_mtime=2010/01/27-12:32:56, st_ctime=2010/02/16-21:30:13}) = 0
+mmap(NULL, 26050, PROT_READ, MAP_SHARED, 3, 0) = 0x7f6d13003000
+close(3)                                = 0
+futex(0x7f6d12410f60, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+open("/usr/lib/rpm/rpmpopt-4.7.1", O_RDONLY) = 3
+lseek(3, 0, SEEK_END)                   = 8577
+lseek(3, 0, SEEK_SET)                   = 0
+read(3, "#/*! \\page config_rpmpopt Defaul"..., 8577) = 8577
+close(3)                                = 0
+open("/etc/popt", O_RDONLY)             = -1 ENOENT (No such file or directory)
+stat("/etc/popt.d", 0x7fffc04767d0)     = -1 ENOENT (No such file or directory)
+open("/root/.popt", O_RDONLY)           = -1 ENOENT (No such file or directory)
+umask(022)                              = 022
+open("/etc/resolv.conf", O_RDONLY)      = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1350672152, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=39, st_atime=2010/05/18-04:05:01, st_mtime=2009/09/02-18:52:38, st_ctime=2010/02/03-01:40:10}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "nameserver 127.0.0.1\nsearch medo"..., 4096) = 39
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+stat("/etc/resolv.conf", {st_dev=makedev(9, 3), st_ino=1350672152, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=39, st_atime=2010/05/18-04:05:01, st_mtime=2009/09/02-18:52:38, st_ctime=2010/02/03-01:40:10}) = 0
+open("/etc/resolv.conf", O_RDONLY)      = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1350672152, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=39, st_atime=2010/05/18-04:05:01, st_mtime=2009/09/02-18:52:38, st_ctime=2010/02/03-01:40:10}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "nameserver 127.0.0.1\nsearch medo"..., 4096) = 39
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+socket(PF_FILE, 0x80801 /* SOCK_??? */, 0) = 3
+connect(3, {sa_family=AF_FILE, path="/var/run/nscd/socket"}, 110) = -1 ENOENT (No such file or directory)
+close(3)                                = 0
+socket(PF_FILE, 0x80801 /* SOCK_??? */, 0) = 3
+connect(3, {sa_family=AF_FILE, path="/var/run/nscd/socket"}, 110) = -1 ENOENT (No such file or directory)
+close(3)                                = 0
+open("/etc/nsswitch.conf", O_RDONLY)    = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1358792995, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=1244, st_atime=2010/05/18-04:05:01, st_mtime=2009/11/16-08:14:47, st_ctime=2009/11/16-08:14:48}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# /etc/nsswitch.conf\n#\n# An ex"..., 4096) = 1244
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/ld.so.cache", O_RDONLY)      = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1358789597, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=184, st_size=91207, st_atime=2010/05/18-08:18:01, st_mtime=2010/05/15-08:17:29, st_ctime=2010/05/15-08:17:29}) = 0
+mmap(NULL, 91207, PROT_READ, MAP_PRIVATE, 3, 0) = 0x7f6d12f97000
+close(3)                                = 0
+open("/lib64/libnss_files.so.2", O_RDONLY) = 3
+read(3, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\200!\0\0\0\0\0\0"..., 832) = 832
+fstat(3, {st_dev=makedev(9, 3), st_ino=2159132328, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=104, st_size=51896, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:19, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2147728, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f6d10dae000
+fadvise64(3, 0, 2147728, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d10db9000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d10fb9000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 3, 0xb000) = 0x7f6d10fb9000
+close(3)                                = 0
+mprotect(0x7f6d10fb9000, 4096, PROT_READ) = 0
+munmap(0x7f6d12f97000, 91207)           = 0
+open("/etc/host.conf", O_RDONLY)        = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1350672057, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=370, st_atime=2010/05/18-04:06:01, st_mtime=2009/10/24-05:00:29, st_ctime=2009/11/15-21:36:53}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# /etc/host.conf - resolver co"..., 4096) = 370
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+futex(0x7f6d12414324, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+open("/etc/hosts", O_RDONLY|O_CLOEXEC)  = 3
+fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
+fstat(3, {st_dev=makedev(9, 3), st_ino=1350672066, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=781, st_atime=2010/05/17-22:43:01, st_mtime=2010/05/02-22:42:08, st_ctime=2010/05/02-22:42:08}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# hosts         This file desc"..., 4096) = 781
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/platform", O_RDONLY)     = -1 ENOENT (No such file or directory)
+uname({sysname="Linux", nodename="borg", release="2.6.33.2-jen97-default", version="#1 SMP 2010-04-02 16:56:15 +0200", machine="x86_64"}) = 0
+stat("/root/.rpmrc", 0x7fffc0476440)    = -1 ENOENT (No such file or directory)
+access("/usr/lib/rpm/rpmrc", R_OK)      = 0
+open("/usr/lib/rpm/rpmrc", O_RDONLY)    = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+fstat(3, {st_dev=makedev(9, 3), st_ino=1143486983, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=32, st_size=15127, st_atime=2010/05/18-14:22:05, st_mtime=2009/11/23-20:58:56, st_ctime=2009/11/25-00:27:55}) = 0
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13001000
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "#/*! \\page config_rpmrc Default "..., 8192) = 8192
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "uildarchtranslate: ppc8560: ppc\n"..., 8192) = 6935
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "", 1257)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13001000, 8192)            = 0
+access("/usr/lib/rpm/suse/rpmrc", R_OK) = -1 ENOENT (No such file or directory)
+access("/etc/rpmrc", R_OK)              = -1 ENOENT (No such file or directory)
+open("/usr/lib/rpm/macros", O_RDONLY)   = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1143487395, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=96, st_size=47636, st_atime=2010/05/18-14:22:05, st_mtime=2010/04/20-08:35:34, st_ctime=2010/04/20-08:35:34}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#/*! \\page config_macros Default"..., 4096) = 4096
+read(3, "hese are the default values that"..., 4096) = 4096
+read(3, "re willing to supply content in "..., 4096) = 4096
+read(3, "\n#\n# Should the build of package"..., 4096) = 4096
+read(3, "i_config_Packages) if defined, o"..., 4096) = 4096
+open("/proc/meminfo", O_RDONLY)         = 4
+fstat(4, {st_dev=makedev(0, 3), st_ino=4026531982, st_mode=S_IFREG|0444, st_nlink=1, st_uid=0, st_gid=0, st_blksize=1024, st_blocks=0, st_size=0, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:19, st_ctime=2010/05/18-14:30:19}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13001000
+read(4, "MemTotal:       12327628 kB\nMemF"..., 1024) = 1024
+close(4)                                = 0
+munmap(0x7f6d13001000, 4096)            = 0
+read(3, "bi_htconfig_rebuild}}\\\n  %{!?_rp"..., 4096) = 4096
+brk(0x2181000)                          = 0x2181000
+brk(0x2180000)                          = 0x2180000
+read(3, " as install hint)\n#\t\t1\tElf32 per"..., 4096) = 4096
+read(3, "sspath:CLASSPATH=\\\"%{_javaclassp"..., 4096) = 4096
+read(3, "ude\n%_infodir\t\t%{_datadir}/info\n"..., 4096) = 4096
+read(3, "=`sed -n -e 's,AM_ACLOCAL_INCLUD"..., 4096) = 4096
+read(3, "port sys; print sys.prefix\" 2>/d"..., 4096) = 4096
+read(3, "IN_CLASS=%1\\\nBASE_FLAGS=%2\\\nBASE"..., 4096) = 2580
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/usr/lib/rpm/platform/x86_64-linux/macros", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1143252470, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2480, st_atime=2010/05/18-14:29:10, st_mtime=2009/11/23-20:58:56, st_ctime=2009/11/25-00:27:55}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "# Per-platform rpm configuration"..., 4096) = 2480
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/usr/lib/rpm/suse/macros", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1143486985, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=32, st_size=14011, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/23-17:57:00, st_ctime=2009/11/25-00:27:55}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "%suse_check \\\n        %{?buildro"..., 4096) = 4096
+read(3, "then \\\n       /sbin/SuSEconfig -"..., 4096) = 4096
+read(3, "    %{-Y:FORCE_YES=1}%{!-Y:FORCE"..., 4096) = 4096
+read(3, "    done\n\n%insserv_force_if_yast"..., 4096) = 1723
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 3
+fcntl(3, F_GETFD)                       = 0x1 (flags FD_CLOEXEC)
+getdents64(3, {{d_ino=1884196071, d_off=4, d_type=DT_UNKNOWN, d_reclen=24, d_name="."} {d_ino=1342177408, d_off=10, d_type=DT_UNKNOWN, d_reclen=24, d_name=".."} {d_ino=1907871135, d_off=18, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.gconf2"} {d_ino=1908328623, d_off=36, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.jpackage"} {d_ino=1906570670, d_off=44, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.mkinitrd"} {d_ino=1908435222, d_off=51, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.python"} {d_ino=1907968609, d_off=67, d_type=DT_UNKNOWN, d_reclen=32, d_name="macros.tcl"} {d_ino=1884196086, d_off=75, d_type=DT_UNKNOWN, d_reclen=32, d_name="macros.perl"} {d_ino=1907871616, d_off=83, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.optipng"} {d_ino=1884042542, d_off=91, d_type=DT_UNKNOWN, d_reclen=32, d_name="macros.php"} {d_ino=1906537303, d_off=512, d_type=DT_UNKNOWN, d_reclen=40, d_name="macros.kernel-source"}}, 32768) = 384
+getdents64(3, {}, 32768)                = 0
+close(3)                                = 0
+open("/etc/rpm/macros.gconf2", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1907871135, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=16, st_size=4585, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/20-10:26:31, st_ctime=2009/11/15-20:30:32}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# RPM macros for gconf applica"..., 4096) = 4096
+read(3, "\n%find_gconf_schemas() \\\ntest -d"..., 4096) = 489
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.jpackage", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1908328623, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9154, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/21-23:57:26, st_ctime=2009/11/15-21:32:08}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# RPM macros for Java applicat"..., 4096) = 4096
+read(3, "LD_ROOT/%{_mavendepmapfragdir}\\\n"..., 4096) = 4096
+read(3, "sh to create\n#\n# already in /usr"..., 4096) = 962
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.kernel-source", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1906537303, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=1968, st_atime=2010/05/18-14:22:05, st_mtime=2010/04/02-20:27:37, st_ctime=2010/04/08-15:15:03}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "# A few cross-distro definitions"..., 4096) = 1968
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.mkinitrd", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1906570670, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=95, st_atime=2010/05/18-14:22:05, st_mtime=2010/02/17-16:29:08, st_ctime=2010/03/07-20:59:58}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# Update links for mkinitrd sc"..., 4096) = 95
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.optipng", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1907871616, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=203, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/19-19:03:12, st_ctime=2009/11/15-20:50:40}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "%optipng() \\\n  find %1 -links 1 "..., 4096) = 203
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.perl", O_RDONLY)  = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1884196086, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4076, st_atime=2010/05/18-14:22:05, st_mtime=2010/03/24-12:45:40, st_ctime=2010/04/04-17:43:57}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "# macros.perl file\n# macros for "..., 4096) = 4076
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.php", O_RDONLY)   = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1884042542, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=88, st_atime=2010/05/18-14:22:05, st_mtime=2010/02/15-18:33:16, st_ctime=2010/02/23-19:52:22}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "#\n# Interface versions exposed b"..., 4096) = 88
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.python", O_RDONLY) = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1908435222, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=1105, st_atime=2010/05/18-14:22:05, st_mtime=2010/03/29-17:31:28, st_ctime=2010/05/15-08:16:34}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "%py_ver\t\t\t%(python -c \"import sy"..., 4096) = 1105
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros.tcl", O_RDONLY)   = 3
+fstat(3, {st_dev=makedev(9, 3), st_ino=1907968609, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=443, st_atime=2010/05/18-14:22:05, st_mtime=2009/10/24-03:31:03, st_ctime=2009/11/15-21:45:21}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "# RPM macros for Tcl\n\n# The mino"..., 4096) = 443
+read(3, "", 4096)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("/etc/rpm/macros", O_RDONLY)       = -1 ENOENT (No such file or directory)
+open("/etc/rpm/x86_64-linux/macros", O_RDONLY) = -1 ENOENT (No such file or directory)
+stat("/root/.rpmmacros", 0x7fffc0476400) = -1 ENOENT (No such file or directory)
+stat("/usr/lib/rpm/init.lua", 0x7fffc0476740) = -1 ENOENT (No such file or directory)
+open("/proc/filesystems", O_RDONLY)     = 3
+fstat(3, {st_dev=makedev(0, 3), st_ino=4026531975, st_mode=S_IFREG|0444, st_nlink=1, st_uid=0, st_gid=0, st_blksize=1024, st_blocks=0, st_size=0, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:19, st_ctime=2010/05/18-14:30:19}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+read(3, "nodev\tsysfs\nnodev\trootfs\nnodev\tb"..., 1024) = 405
+read(3, "", 1024)                       = 0
+close(3)                                = 0
+munmap(0x7f6d13002000, 4096)            = 0
+open("ts-0-0.x86_64.rpm", O_RDONLY)     = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\355\253\356\333\3\0\0\0\0\1ts-0-0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 96) = 96
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\216\255\350\1\0\0\0\0\0\0\0\5\0\0\0T", 16) = 16
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\0\0\0>\0\0\0\7\0\0\0D\0\0\0\20\0\0\1\r\0\0\0\6\0\0\0\0\0\0\0\1"..., 164) = 164
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\0\0\0\0", 4)                  = 4
+fstat(3, {st_dev=makedev(9, 3), st_ino=837363081, st_mode=S_IFREG|0644, st_nlink=1, st_uid=25121, st_gid=100, st_blksize=4096, st_blocks=8, st_size=1621, st_atime=2010/05/18-14:29:51, st_mtime=2010/05/18-14:29:41, st_ctime=2010/05/18-14:29:49}) = 0
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\216\255\350\1\0\0\0\0\0\0\0+\0\0\1\331", 16) = 16
+poll([{fd=3, events=POLLIN}], 1, 1000)  = 1 ([{fd=3, revents=POLLIN}])
+read(3, "\0\0\0?\0\0\0\7\0\0\1\311\0\0\0\20\0\0\0d\0\0\0\10\0\0\0\0\0\0\0\1"..., 1161) = 1161
+open("/var/lib/rpm/pubkeys", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+access("/var/lib/rpm/Packages", F_OK)   = 0
+open("/proc/stat", O_RDONLY|O_CLOEXEC)  = 4
+read(4, "cpu  15726338 2232232 15373122 1"..., 8192) = 1720
+close(4)                                = 0
+stat("/var/lib/rpm/DB_CONFIG", 0x7fffc04660e0) = -1 ENOENT (No such file or directory)
+open("/var/lib/rpm/DB_CONFIG", O_RDONLY) = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/__db.002", 0x7fffc0466180) = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/__db.003", 0x7fffc04661b0) = -1 ENOENT (No such file or directory)
+brk(0x21a2000)                          = 0x21a2000
+brk(0x21c3000)                          = 0x21c3000
+brk(0x21e4000)                          = 0x21e4000
+brk(0x2205000)                          = 0x2205000
+stat("/var/lib/rpm/Packages", {st_dev=makedev(9, 3), st_ino=3779703544, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=72344, st_size=37040128, st_atime=2010/05/18-14:30:17, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Packages", O_RDONLY) = 4
+fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
+read(4, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\377\20\0\0"..., 512) = 512
+close(4)                                = 0
+open("/var/lib/rpm/Packages", O_RDONLY) = 4
+fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
+fstat(4, {st_dev=makedev(9, 3), st_ino=3779703544, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=72344, st_size=37040128, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(4, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\377\20\0\0"..., 4096, 0) = 4096
+fcntl(4, F_SETLK, {type=F_RDLCK, whence=SEEK_SET, start=0, len=0}) = 0
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+brk(0x2226000)                          = 0x2226000
+brk(0x2222000)                          = 0x2222000
+brk(0x221e000)                          = 0x221e000
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+access("/var/lib/rpm/Name", F_OK)       = 0
+stat("/var/lib/rpm/Name", {st_dev=makedev(9, 3), st_ino=3779703545, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=96, st_size=49152, st_atime=2010/05/18-14:30:17, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Name", O_RDONLY)     = 5
+fcntl(5, F_SETFD, FD_CLOEXEC)           = 0
+read(5, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 512) = 512
+close(5)                                = 0
+open("/var/lib/rpm/Name", O_RDONLY)     = 5
+fcntl(5, F_SETFD, FD_CLOEXEC)           = 0
+fstat(5, {st_dev=makedev(9, 3), st_ino=3779703545, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=96, st_size=49152, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(5, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 4096, 0) = 4096
+pread(5, "\0\0\0\0\1\0\0\0\5\0\0\0\0\0\0\0\v\0\0\0J\1\270\2\0\2\366\17\355\17\335\17"..., 4096, 20480) = 4096
+pread(5, "\0\0\0\0\1\0\0\0\v\0\0\0\5\0\0\0\0\0\0\0\276\0\204\7\0\2\353\17\342\17\326\17"..., 4096, 45056) = 4096
+pread(4, "\0\0\0\0\1\0\0\0000\n\0\0\0\0\0\0,\n\0\0~\1Q\3\0\2\373\17\357\17\352\17"..., 4096, 10682368) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\276\2\0\0\0\0\0\0\0\0\0\0\1\0\210\t\0\7\0\0\0\23\0\0"..., 4096, 2875392) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\335\30\0\0\0\0\0\0\0\0\0\0\n\1+\7\0\2\373\17\357\17\352\17"..., 4096, 26071040) = 4096
+pread(4, "\0\0\0\0\1\0\0\0T\5\0\0\0\0\0\0U\5\0\0\1\0\346\17\0\7\0\0\0\22\0\0"..., 4096, 5586944) = 4096
+pread(4, "\0\0\0\0\1\0\0\0U\5\0\0T\5\0\0\0\0\0\0\1\0z\4\0\7MQsSj1"..., 4096, 5591040) = 4096
+pread(4, "\0\0\0\0\1\0\0\0n\7\0\0\0\0\0\0\0\0\0\0\1\0\354\t\0\7\0\0\0\23\0\0"..., 4096, 7790592) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\25\10\0\0\0\0\0\0\26\10\0\0\1\0\346\17\0\7\0\0\0\22\0\0"..., 4096, 8474624) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\26\10\0\0\25\10\0\0\0\0\0\0\1\0J\0\0\007478a32"..., 4096, 8478720) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\10\1C\7\0\2\373\17\366\17\361\17"..., 4096, 4096) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\27\10\0\0\0\0\0\0\30\10\0\0\1\0\346\17\0\7\0\0\0\22\0\0"..., 4096, 8482816) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\30\10\0\0\27\10\0\0\0\0\0\0\1\0\336\1\0\7AG4kk+"..., 4096, 8486912) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\336\30\0\0\0\0\0\0\0\0\0\0\n\1+\7\0\2\373\17\357\17\352\17"..., 4096, 26075136) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\31\10\0\0\0\0\0\0\32\10\0\0\1\0\346\17\0\7\0\0\0\22\0\0"..., 4096, 8491008) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\32\10\0\0\31\10\0\0\0\0\0\0\1\0\332\2\0\7kNmPhq"..., 4096, 8495104) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\34\10\0\0\0\0\0\0\0\0\0\0\1\0\360\t\0\7\0\0\0\22\0\0"..., 4096, 8503296) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\35\10\0\0\0\0\0\0\0\0\0\0\1\0\340\t\0\7\0\0\0\22\0\0"..., 4096, 8507392) = 4096
+pread(4, "\0\0\0\0\1\0\0\0/\n\0\0\0\0\0\0\341\30\0\0~\1Q\3\0\2\373\17\357\17\352\17"..., 4096, 10678272) = 4096
+pread(4, "\0\0\0\0\1\0\0\0 \10\0\0\0\0\0\0\0\0\0\0\1\0\370\t\0\7\0\0\0\22\0\0"..., 4096, 8519680) = 4096
+brk(0x223f000)                          = 0x223f000
+pread(4, "\0\0\0\0\1\0\0\0\235\n\0\0\0\0\0\0\0\0\0\0\1\0\264\t\0\7\0\0\0\23\0\0"..., 4096, 11128832) = 4096
+pread(4, "\0\0\0\0\1\0\0\0x\16\0\0\0\0\0\0\0\0\0\0\1\0\230\t\0\7\0\0\0\22\0\0"..., 4096, 15171584) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\237\16\0\0\0\0\0\0\0\0\0\0\1\0\370\t\0\7\0\0\0\22\0\0"..., 4096, 15331328) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\242\16\0\0\0\0\0\0\0\0\0\0\1\0000\n\0\7\0\0\0\22\0\0"..., 4096, 15343616) = 4096
+pread(4, "\0\0\0\0\1\0\0\0v\25\0\0\0\0\0\0\0\0\0\0\1\0\30\n\0\7\0\0\0\22\0\0"..., 4096, 22503424) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\341\30\0\0/\n\0\0\0\0\0\0\222\0'\v\0\2\373\17\357\17\352\17"..., 4096, 26087424) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\302\32\0\0\0\0\0\0\0\0\0\0\1\0\254\10\0\7\0\0\0\22\0\0"..., 4096, 28057600) = 4096
+pread(4, "\0\0\0\0\1\0\0\0,\n\0\0000\n\0\0\0\0\0\0\220\0008\v\0\2\373\17\357\17\352\17"..., 4096, 10665984) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\303\32\0\0\0\0\0\0\0\0\0\0\1\0\340\t\0\7\0\0\0\22\0\0"..., 4096, 28061696) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\270\36\0\0\0\0\0\0\0\0\0\0\1\0\360\t\0\7\0\0\0\22\0\0"..., 4096, 32210944) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\271\36\0\0\0\0\0\0\0\0\0\0\1\0\374\16\0\7\0\0\0\22\0\0"..., 4096, 32215040) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0\0\0\0\0\2\1o\7\0\2\373\17\357\17\352\17"..., 4096, 8192) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\272\36\0\0\0\0\0\0\0\0\0\0\1\0\224\6\0\7\0\0\0\22\0\0"..., 4096, 32219136) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+close(3)                                = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+brk(0x2260000)                          = 0x2260000
+brk(0x225c000)                          = 0x225c000
+brk(0x2258000)                          = 0x2258000
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+access("/var/lib/rpm/Conflictname", F_OK) = 0
+stat("/var/lib/rpm/Conflictname", {st_dev=makedev(9, 3), st_ino=3779704855, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=12288, st_atime=2010/05/18-10:56:45, st_mtime=2010/05/15-08:34:33, st_ctime=2010/05/15-08:34:33}) = 0
+open("/var/lib/rpm/Conflictname", O_RDONLY) = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+read(3, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 512) = 512
+close(3)                                = 0
+open("/var/lib/rpm/Conflictname", O_RDONLY) = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+fstat(3, {st_dev=makedev(9, 3), st_ino=3779704855, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=12288, st_atime=2010/05/18-10:56:45, st_mtime=2010/05/15-08:34:33, st_ctime=2010/05/15-08:34:33}) = 0
+pread(3, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(3, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0\0\0\0\0F\0\367\f\0\2\360\17\347\17\336\17"..., 4096, 8192) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+umask(022)                              = 022
+open("/var/lib/rpm/__db.000", O_RDWR|O_CREAT, 0644) = 6
+umask(022)                              = 022
+fcntl(6, F_SETLK, {type=F_WRLCK, whence=SEEK_SET, start=0, len=0}) = 0
+close(3)                                = 0
+close(5)                                = 0
+close(4)                                = 0
+rt_sigaction(SIGHUP, NULL, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGHUP, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGINT, NULL, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGINT, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGTERM, NULL, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGTERM, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGQUIT, NULL, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGQUIT, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGPIPE, NULL, {SIG_DFL, [], 0}, 8) = 0
+rt_sigaction(SIGPIPE, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, {SIG_DFL, [], 0}, 8) = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+open("/proc/stat", O_RDONLY|O_CLOEXEC)  = 3
+read(3, "cpu  15726339 2232232 15373122 1"..., 8192) = 1720
+close(3)                                = 0
+stat("/var/lib/rpm/DB_CONFIG", 0x7fffc04761e0) = -1 ENOENT (No such file or directory)
+open("/var/lib/rpm/DB_CONFIG", O_RDONLY) = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/__db.002", 0x7fffc0476280) = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/__db.003", 0x7fffc04762b0) = -1 ENOENT (No such file or directory)
+brk(0x2244000)                          = 0x2244000
+stat("/var/lib/rpm/Packages", {st_dev=makedev(9, 3), st_ino=3779703544, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=72344, st_size=37040128, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Packages", O_RDWR)   = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+read(3, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\377\20\0\0"..., 512) = 512
+close(3)                                = 0
+open("/var/lib/rpm/Packages", O_RDWR)   = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+fstat(3, {st_dev=makedev(9, 3), st_ino=3779703544, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=72344, st_size=37040128, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(3, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\377\20\0\0"..., 4096, 0) = 4096
+fcntl(3, F_SETLK, {type=F_WRLCK, whence=SEEK_SET, start=0, len=0}) = 0
+getcwd("/home/jengelh/lbuild/input/ts", 128) = 30
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Name", {st_dev=makedev(9, 3), st_ino=3779703545, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=96, st_size=49152, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Name", O_RDWR)       = 4
+fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
+read(4, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 512) = 512
+close(4)                                = 0
+open("/var/lib/rpm/Name", O_RDWR)       = 4
+fcntl(4, F_SETFD, FD_CLOEXEC)           = 0
+fstat(4, {st_dev=makedev(9, 3), st_ino=3779703545, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=96, st_size=49152, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(4, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 4096, 0) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\5\0\0\0\0\0\0\0\v\0\0\0J\1\270\2\0\2\366\17\355\17\335\17"..., 4096, 20480) = 4096
+pread(4, "\0\0\0\0\1\0\0\0\v\0\0\0\5\0\0\0\0\0\0\0\276\0\204\7\0\2\353\17\342\17\326\17"..., 4096, 45056) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+chdir("/")                              = 0
+fstat(1, {st_dev=makedev(0, 12), st_ino=10, st_mode=S_IFCHR|0600, st_nlink=1, st_uid=25121, st_gid=5, st_blksize=1024, st_blocks=0, st_rdev=makedev(136, 7), st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:19, st_ctime=2010/05/18-14:24:59}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13002000
+write(1, "Preparing...                ", 28) = 28
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+stat("/", {st_dev=makedev(9, 3), st_ino=128, st_mode=S_IFDIR|0755, st_nlink=28, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/18-14:30:02, st_mtime=2010/05/18-14:30:03, st_ctime=2010/05/18-14:30:03}) = 0
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Basenames", {st_dev=makedev(9, 3), st_ino=3779703665, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=9520, st_size=5455872, st_atime=2010/05/18-14:30:17, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Basenames", O_RDWR)  = 5
+fcntl(5, F_SETFD, FD_CLOEXEC)           = 0
+read(5, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\264\0\0\0"..., 512) = 512
+close(5)                                = 0
+open("/var/lib/rpm/Basenames", O_RDWR)  = 5
+fcntl(5, F_SETFD, FD_CLOEXEC)           = 0
+fstat(5, {st_dev=makedev(9, 3), st_ino=3779703665, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=9520, st_size=5455872, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(5, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\264\0\0\0"..., 4096, 0) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+pread(5, "\0\0\0\0\1\0\0\0\316\1\0\0\0\0\0\0\0\0\0\0\342\0\212\4\0\2\361\17\340\17\312\17"..., 4096, 1892352) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+statfs("/", {f_type=0x58465342, f_bsize=4096, f_blocks=365698971, f_bfree=188677221, f_bavail=188677221, f_files=292585344, f_ffree=291625617, f_fsid={2307, 0}, f_namelen=255, f_frsize=4096}) = 0
+stat("/", {st_dev=makedev(9, 3), st_ino=128, st_mode=S_IFDIR|0755, st_nlink=28, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/18-14:30:02, st_mtime=2010/05/18-14:30:03, st_ctime=2010/05/18-14:30:03}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "                                "..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "                    (100%)\10\10\10\10\10\10"..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "%)\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10"..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10####"..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "\10\10\10\10############################"..., 304) = 304
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "################################"..., 51) = 51
+chdir("/home/jengelh/lbuild/input/ts")  = 0
+open("ts-0-0.x86_64.rpm", O_RDONLY)     = 7
+fcntl(7, F_SETFD, FD_CLOEXEC)           = 0
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\355\253\356\333\3\0\0\0\0\1ts-0-0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 96) = 96
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\216\255\350\1\0\0\0\0\0\0\0\5\0\0\0T", 16) = 16
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\0\0\0>\0\0\0\7\0\0\0D\0\0\0\20\0\0\1\r\0\0\0\6\0\0\0\0\0\0\0\1"..., 164) = 164
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\0\0\0\0", 4)                  = 4
+fstat(7, {st_dev=makedev(9, 3), st_ino=837363081, st_mode=S_IFREG|0644, st_nlink=1, st_uid=25121, st_gid=100, st_blksize=4096, st_blocks=8, st_size=1621, st_atime=2010/05/18-14:29:51, st_mtime=2010/05/18-14:29:41, st_ctime=2010/05/18-14:29:49}) = 0
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\216\255\350\1\0\0\0\0\0\0\0+\0\0\1\331", 16) = 16
+poll([{fd=7, events=POLLIN}], 1, 1000)  = 1 ([{fd=7, revents=POLLIN}])
+read(7, "\0\0\0?\0\0\0\7\0\0\1\311\0\0\0\20\0\0\0d\0\0\0\10\0\0\0\0\0\0\0\1"..., 1161) = 1161
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Triggername", {st_dev=makedev(9, 3), st_ino=3779704928, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=12288, st_atime=2010/05/18-10:56:54, st_mtime=2010/05/15-08:17:19, st_ctime=2010/05/15-08:17:19}) = 0
+open("/var/lib/rpm/Triggername", O_RDWR) = 8
+fcntl(8, F_SETFD, FD_CLOEXEC)           = 0
+read(8, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 512) = 512
+close(8)                                = 0
+open("/var/lib/rpm/Triggername", O_RDWR) = 8
+fcntl(8, F_SETFD, FD_CLOEXEC)           = 0
+fstat(8, {st_dev=makedev(9, 3), st_ino=3779704928, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=12288, st_atime=2010/05/18-10:56:54, st_mtime=2010/05/15-08:17:19, st_ctime=2010/05/15-08:17:19}) = 0
+pread(8, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(8, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0\0\0\0\0\10\0\233\17\0\2\370\17\357\17\334\17"..., 4096, 8192) = 4096
+dup(7)                                  = 9
+fcntl(9, F_GETFL)                       = 0x8000 (flags O_RDONLY|O_LARGEFILE)
+fstat(9, {st_dev=makedev(9, 3), st_ino=837363081, st_mode=S_IFREG|0644, st_nlink=1, st_uid=25121, st_gid=100, st_blksize=4096, st_blocks=8, st_size=1621, st_atime=2010/05/18-14:29:51, st_mtime=2010/05/18-14:29:41, st_ctime=2010/05/18-14:29:49}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d13001000
+lseek(9, 0, SEEK_CUR)                   = 1457
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "   1:ts                     ", 28) = 28
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12fff000
+read(9, "\3757zXZ\0\0\n\341\373\f\241\2\0!\1\34\0\0\0\20\317X\314\340\0\363\0K]\0\30"..., 32768) = 164
+read(9, "", 28672)                      = 0
+brk(0x226a000)                          = 0x226a000
+mmap(NULL, 67112960, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d0cdad000
+socket(PF_FILE, 0x80801 /* SOCK_??? */, 0) = 10
+connect(10, {sa_family=AF_FILE, path="/var/run/nscd/socket"}, 110) = -1 ENOENT (No such file or directory)
+close(10)                               = 0
+socket(PF_FILE, 0x80801 /* SOCK_??? */, 0) = 10
+connect(10, {sa_family=AF_FILE, path="/var/run/nscd/socket"}, 110) = -1 ENOENT (No such file or directory)
+close(10)                               = 0
+open("/etc/ld.so.cache", O_RDONLY)      = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1358789597, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=184, st_size=91207, st_atime=2010/05/18-08:18:01, st_mtime=2010/05/15-08:17:29, st_ctime=2010/05/15-08:17:29}) = 0
+mmap(NULL, 91207, PROT_READ, MAP_PRIVATE, 10, 0) = 0x7f6d12f97000
+close(10)                               = 0
+open("/lib64/libnss_compat.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220\23\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159132324, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=64, st_size=31800, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:19, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2127088, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0cba5000
+fadvise64(10, 0, 2127088, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0cbac000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0cdab000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x6000) = 0x7f6d0cdab000
+close(10)                               = 0
+open("/lib64/libnsl.so.1", O_RDONLY)    = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340@\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159132323, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=176, st_size=89240, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:19, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2194128, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0c98d000
+fadvise64(10, 0, 2194128, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0c9a2000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0cba1000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x14000) = 0x7f6d0cba1000
+mmap(0x7f6d0cba3000, 6864, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d0cba3000
+close(10)                               = 0
+mprotect(0x7f6d0cba1000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0cdab000, 4096, PROT_READ) = 0
+munmap(0x7f6d12f97000, 91207)           = 0
+open("/etc/ld.so.cache", O_RDONLY)      = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1358789597, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=184, st_size=91207, st_atime=2010/05/18-08:18:01, st_mtime=2010/05/15-08:17:29, st_ctime=2010/05/15-08:17:29}) = 0
+mmap(NULL, 91207, PROT_READ, MAP_PRIVATE, 10, 0) = 0x7f6d12f97000
+close(10)                               = 0
+open("/lib64/libnss_nis.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220 \0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159132332, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=88, st_size=43736, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:19, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2139352, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0c782000
+fadvise64(10, 0, 2139352, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0c78c000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0c98b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x9000) = 0x7f6d0c98b000
+close(10)                               = 0
+mprotect(0x7f6d0c98b000, 4096, PROT_READ) = 0
+munmap(0x7f6d12f97000, 91207)           = 0
+open("/etc/passwd", O_RDONLY|O_CLOEXEC) = 10
+fcntl(10, F_GETFD)                      = 0x1 (flags FD_CLOEXEC)
+lseek(10, 0, SEEK_CUR)                  = 0
+fstat(10, {st_dev=makedev(9, 3), st_ino=1358995409, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2985, st_atime=2010/05/18-14:09:01, st_mtime=2010/05/05-14:08:52, st_ctime=2010/05/05-14:08:52}) = 0
+mmap(NULL, 2985, PROT_READ, MAP_SHARED, 10, 0) = 0x7f6d12ffe000
+lseek(10, 2985, SEEK_SET)               = 2985
+fstat(10, {st_dev=makedev(9, 3), st_ino=1358995409, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2985, st_atime=2010/05/18-14:09:01, st_mtime=2010/05/05-14:08:52, st_ctime=2010/05/05-14:08:52}) = 0
+munmap(0x7f6d12ffe000, 2985)            = 0
+close(10)                               = 0
+open("/etc/ld.so.cache", O_RDONLY)      = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1358789597, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=184, st_size=91207, st_atime=2010/05/18-08:18:01, st_mtime=2010/05/15-08:17:29, st_ctime=2010/05/15-08:17:29}) = 0
+mmap(NULL, 91207, PROT_READ, MAP_PRIVATE, 10, 0) = 0x7f6d12f97000
+close(10)                               = 0
+open("/lib64/libnss_ldap.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\2209\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159090035, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=168, st_size=85368, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/19-21:18:03, st_ctime=2009/11/15-21:36:25}) = 0
+mmap(NULL, 2227584, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0c562000
+fadvise64(10, 0, 2227584, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0c576000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0c775000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x13000) = 0x7f6d0c775000
+mmap(0x7f6d0c777000, 44416, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d0c777000
+close(10)                               = 0
+open("/usr/lib64/libldap-2.4.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0 \352\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507172602, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=560, st_size=282648, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/24-06:55:26, st_ctime=2009/11/15-20:26:30}) = 0
+mmap(NULL, 2377696, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0c31d000
+fadvise64(10, 0, 2377696, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0c360000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0c55f000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x42000) = 0x7f6d0c55f000
+close(10)                               = 0
+open("/usr/lib64/liblber-2.4.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\3209\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507172599, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=128, st_size=64680, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/24-06:55:25, st_ctime=2009/11/15-20:26:30}) = 0
+mmap(NULL, 2159912, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0c10d000
+fadvise64(10, 0, 2159912, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0c11c000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0c31b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0xe000) = 0x7f6d0c31b000
+close(10)                               = 0
+open("/usr/lib64/libgssapi_krb5.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@s\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507138203, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=384, st_size=193328, st_atime=2010/05/17-20:08:01, st_mtime=2010/04/22-01:37:08, st_ctime=2010/04/24-20:07:02}) = 0
+mmap(NULL, 2288864, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0bede000
+fadvise64(10, 0, 2288864, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0bf0b000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d0c10b000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x2d000) = 0x7f6d0c10b000
+close(10)                               = 0
+open("/lib64/libresolv.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\3408\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159133547, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=160, st_size=80896, st_atime=2010/05/18-04:05:01, st_mtime=2010/01/27-12:43:20, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 2185864, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0bcc8000
+fadvise64(10, 0, 2185864, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0bcdb000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0beda000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x12000) = 0x7f6d0beda000
+mmap(0x7f6d0bedc000, 6792, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d0bedc000
+close(10)                               = 0
+open("/usr/lib64/libsasl2.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@M\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507166268, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=208, st_size=106344, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/19-20:47:54, st_ctime=2009/11/15-20:57:37}) = 0
+mmap(NULL, 2201552, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0baae000
+fadvise64(10, 0, 2201552, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0bac7000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0bcc6000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x18000) = 0x7f6d0bcc6000
+close(10)                               = 0
+open("/usr/lib64/libssl.so.0.9.8", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220@\1\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507172558, st_mode=S_IFREG|0555, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=656, st_size=334768, st_atime=2010/05/18-04:16:01, st_mtime=2010/04/01-11:42:13, st_ctime=2010/04/07-04:15:54}) = 0
+mmap(NULL, 2429968, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0b85c000
+fadvise64(10, 0, 2429968, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0b8a7000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0baa6000, 32768, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x4a000) = 0x7f6d0baa6000
+close(10)                               = 0
+open("/usr/lib64/libcrypto.so.0.9.8", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\220\245\6\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507164546, st_mode=S_IFREG|0555, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=3144, st_size=1605840, st_atime=2010/05/18-04:16:01, st_mtime=2010/04/01-11:42:13, st_ctime=2010/04/07-04:15:54}) = 0
+mmap(NULL, 3715896, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0b4d0000
+fadvise64(10, 0, 3715896, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0b633000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0b832000, 155648, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x162000) = 0x7f6d0b832000
+mmap(0x7f6d0b858000, 13112, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x7f6d0b858000
+close(10)                               = 0
+open("/usr/lib64/libkrb5.so.3", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0P\231\1\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507172539, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=1512, st_size=771352, st_atime=2010/05/17-20:08:01, st_mtime=2010/04/22-01:37:09, st_ctime=2010/04/24-20:07:02}) = 0
+mmap(NULL, 2867072, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0b214000
+fadvise64(10, 0, 2867072, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0b2c6000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d0b4c6000, 40960, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0xb2000) = 0x7f6d0b4c6000
+close(10)                               = 0
+open("/usr/lib64/libk5crypto.so.3", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0@\\\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507141933, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=352, st_size=179280, st_atime=2010/05/17-20:08:01, st_mtime=2010/04/22-01:37:08, st_ctime=2010/04/24-20:07:02}) = 0
+mmap(NULL, 2275464, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0afe8000
+fadvise64(10, 0, 2275464, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0b012000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0b211000, 12288, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x29000) = 0x7f6d0b211000
+close(10)                               = 0
+open("/lib64/libcom_err.so.2", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\340\23\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159089885, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=32, st_size=14720, st_atime=2010/05/18-04:05:01, st_mtime=2009/10/19-20:28:26, st_ctime=2009/11/15-20:26:25}) = 0
+mmap(NULL, 2109840, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0ade4000
+fadvise64(10, 0, 2109840, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0ade7000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0afe6000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x2000) = 0x7f6d0afe6000
+close(10)                               = 0
+open("/usr/lib64/libkrb5support.so.0", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0 $\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=3507172541, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=72, st_size=35488, st_atime=2010/05/17-20:08:01, st_mtime=2010/04/22-01:37:10, st_ctime=2010/04/24-20:07:02}) = 0
+mmap(NULL, 2130768, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0abdb000
+fadvise64(10, 0, 2130768, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0abe2000, 2097152, PROT_NONE) = 0
+mmap(0x7f6d0ade2000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x7000) = 0x7f6d0ade2000
+close(10)                               = 0
+open("/lib64/libkeyutils.so.1", O_RDONLY) = 10
+read(10, "\177ELF\2\1\1\0\0\0\0\0\0\0\0\0\3\0>\0\1\0\0\0\260\v\0\0\0\0\0\0"..., 832) = 832
+fstat(10, {st_dev=makedev(9, 3), st_ino=2159090022, st_mode=S_IFREG|0755, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=10336, st_atime=2010/05/18-04:06:01, st_mtime=2009/10/24-05:05:55, st_ctime=2009/11/15-21:34:47}) = 0
+mmap(NULL, 2105424, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 10, 0) = 0x7f6d0a9d8000
+fadvise64(10, 0, 2105424, POSIX_FADV_WILLNEED) = 0
+mprotect(0x7f6d0a9da000, 2093056, PROT_NONE) = 0
+mmap(0x7f6d0abd9000, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_FIXED|MAP_DENYWRITE, 10, 0x1000) = 0x7f6d0abd9000
+close(10)                               = 0
+mprotect(0x7f6d0abd9000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0ade2000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0afe6000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0b211000, 8192, PROT_READ) = 0
+mprotect(0x7f6d0b4c6000, 32768, PROT_READ) = 0
+mprotect(0x7f6d0b832000, 57344, PROT_READ) = 0
+mprotect(0x7f6d0baa6000, 8192, PROT_READ) = 0
+mprotect(0x7f6d0bcc6000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0beda000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0c10b000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0c31b000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0c55f000, 4096, PROT_READ) = 0
+mprotect(0x7f6d0c775000, 4096, PROT_READ) = 0
+munmap(0x7f6d12f97000, 91207)           = 0
+rt_sigaction(SIGPIPE, {0x1, [], SA_RESTORER, 0x7f6d120ed560}, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d12424c00}, 8) = 0
+geteuid()                               = 0
+futex(0x7f6d0c776548, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+open("/etc/ldap.conf", O_RDONLY)        = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1357234870, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9554, st_atime=2010/05/18-01:30:01, st_mtime=2010/05/13-01:29:36, st_ctime=2010/05/13-01:29:37}) = 0
+fstat(10, {st_dev=makedev(9, 3), st_ino=1357234870, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9554, st_atime=2010/05/18-01:30:01, st_mtime=2010/05/13-01:29:36, st_ctime=2010/05/13-01:29:37}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "#\n# This is the configuration fi"..., 4096) = 4096
+read(10, "th Novell\n# Directory Services ("..., 4096) = 4096
+read(10, "ctclass automountMap nisMap\n#nss"..., 4096) = 1362
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+open("/etc/ldap.secret", O_RDONLY)      = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672095, st_mode=S_IFREG|0600, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=18, st_atime=2010/05/18-04:06:01, st_mtime=2009/09/03-15:04:44, st_ctime=2009/09/14-17:06:17}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "thism2as4evafuk4u!", 4096)    = 18
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+uname({sysname="Linux", nodename="borg", release="2.6.33.2-jen97-default", version="#1 SMP 2010-04-02 16:56:15 +0200", machine="x86_64"}) = 0
+open("/etc/hosts", O_RDONLY|O_CLOEXEC)  = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672066, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=781, st_atime=2010/05/17-22:43:01, st_mtime=2010/05/02-22:42:08, st_ctime=2010/05/02-22:42:08}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "#\n# hosts         This file desc"..., 4096) = 781
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+open("/etc/openldap/ldap.conf", O_RDONLY) = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672203, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=212, st_atime=2010/05/18-04:06:01, st_mtime=2009/09/02-19:00:29, st_ctime=2009/09/14-17:06:26}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "#\n# LDAP Defaults\n#\n\n# See ldap."..., 4096) = 212
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+geteuid()                               = 0
+getuid()                                = 0
+open("/root/ldaprc", O_RDONLY)          = -1 ENOENT (No such file or directory)
+open("/root/.ldaprc", O_RDONLY)         = -1 ENOENT (No such file or directory)
+open("ldaprc", O_RDONLY)                = -1 ENOENT (No such file or directory)
+stat("/etc/ldap.conf", {st_dev=makedev(9, 3), st_ino=1357234870, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9554, st_atime=2010/05/18-01:30:01, st_mtime=2010/05/13-01:29:36, st_ctime=2010/05/13-01:29:37}) = 0
+geteuid()                               = 0
+socket(PF_NETLINK, SOCK_RAW, 0)         = 10
+bind(10, {sa_family=AF_NETLINK, pid=0, groups=00000000}, 12) = 0
+getsockname(10, {sa_family=AF_NETLINK, pid=8885, groups=00000000}, [12]) = 0
+sendto(10, "\24\0\0\0\26\0\1\3[\210\362K\0\0\0\0\0\0\0\0", 20, 0, {sa_family=AF_NETLINK, pid=0, groups=00000000}, 12) = 20
+recvmsg(10, {msg_name(12)={sa_family=AF_NETLINK, pid=0, groups=00000000}, msg_iov(1)=[{"8\0\0\0\24\0\2\0[\210\362K\265\"\0\0\2\10\200\376\1\0\0\0\10\0\1\0\177\0\0\1"..., 4096}], msg_controllen=0, msg_flags=0}, 0) = 504
+recvmsg(10, {msg_name(12)={sa_family=AF_NETLINK, pid=0, groups=00000000}, msg_iov(1)=[{"@\0\0\0\24\0\2\0[\210\362K\265\"\0\0\n\200\200\376\1\0\0\0\24\0\1\0\0\0\0\0"..., 4096}], msg_controllen=0, msg_flags=0}, 0) = 704
+recvmsg(10, {msg_name(12)={sa_family=AF_NETLINK, pid=0, groups=00000000}, msg_iov(1)=[{"\24\0\0\0\3\0\2\0[\210\362K\265\"\0\0\0\0\0\0\1\0\0\0\24\0\1\0\0\0\0\0"..., 4096}], msg_controllen=0, msg_flags=0}, 0) = 20
+close(10)                               = 0
+open("/etc/hosts", O_RDONLY|O_CLOEXEC)  = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672066, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=781, st_atime=2010/05/17-22:43:01, st_mtime=2010/05/02-22:42:08, st_ctime=2010/05/02-22:42:08}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "#\n# hosts         This file desc"..., 4096) = 781
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+open("/etc/gai.conf", O_RDONLY)         = 10
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672184, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2689, st_atime=2010/05/18-09:51:11, st_mtime=2010/01/27-12:43:15, st_ctime=2010/02/16-21:26:56}) = 0
+fstat(10, {st_dev=makedev(9, 3), st_ino=1350672184, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2689, st_atime=2010/05/18-09:51:11, st_mtime=2010/01/27-12:43:15, st_ctime=2010/02/16-21:26:56}) = 0
+mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f6d12ffe000
+read(10, "# Configuration for getaddrinfo("..., 4096) = 2689
+read(10, "", 4096)                      = 0
+close(10)                               = 0
+munmap(0x7f6d12ffe000, 4096)            = 0
+futex(0x7f6d12412ea4, FUTEX_WAKE_PRIVATE, 2147483647) = 0
+socket(PF_INET6, SOCK_DGRAM, IPPROTO_IP) = 10
+connect(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, 28) = 0
+getsockname(10, {sa_family=AF_INET6, sin6_port=htons(33302), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+connect(10, {sa_family=AF_UNSPEC, sa_data="\0\0\0\0\0\0\0\0\0\0\0\0\0\0"}, 16) = 0
+connect(10, {sa_family=AF_INET, sin_port=htons(389), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
+getsockname(10, {sa_family=AF_INET6, sin6_port=htons(52034), inet_pton(AF_INET6, "::ffff:127.0.0.1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+close(10)                               = 0
+socket(PF_INET6, SOCK_STREAM, IPPROTO_IP) = 10
+fcntl(10, F_SETFD, FD_CLOEXEC)          = 0
+setsockopt(10, SOL_SOCKET, SO_KEEPALIVE, [1], 4) = 0
+setsockopt(10, SOL_TCP, TCP_NODELAY, [1], 4) = 0
+fcntl(10, F_GETFL)                      = 0x2 (flags O_RDWR)
+fcntl(10, F_SETFL, O_RDWR|O_NONBLOCK)   = 0
+connect(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, 28) = -1 EINPROGRESS (Operation now in progress)
+poll([{fd=10, events=POLLOUT|POLLERR|POLLHUP}], 1, 5000) = 1 ([{fd=10, revents=POLLOUT}])
+getpeername(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+fcntl(10, F_GETFL)                      = 0x802 (flags O_RDWR|O_NONBLOCK)
+fcntl(10, F_SETFL, O_RDWR)              = 0
+write(10, "0,\2\1\1`'\2\1\3\4\16cn=root,o=borg\200\22this"..., 46) = 46
+poll([{fd=10, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 5000) = 1 ([{fd=10, revents=POLLIN}])
+read(10, "0\f\2\1\1a\7\n", 8)           = 8
+read(10, "\1\0\4\0\4\0", 6)             = 6
+setsockopt(10, SOL_SOCKET, SO_KEEPALIVE, [0], 4) = 0
+fcntl(10, F_SETFD, FD_CLOEXEC)          = 0
+getsockname(10, {sa_family=AF_INET6, sin6_port=htons(60020), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+getpeername(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+write(10, "0\201\274\2\1\2c\201\266\4\17ou=users,o=borg\n\1\2\n\1\0"..., 191) = 191
+poll([{fd=10, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 5000) = 1 ([{fd=10, revents=POLLIN}])
+read(10, "0\f\2\1\2e\7\n", 8)           = 8
+read(10, "\1\0\4\0\4\0", 6)             = 6
+rt_sigaction(SIGPIPE, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d120ed560}, NULL, 8) = 0
+open("/etc/passwd", O_RDONLY|O_CLOEXEC) = 11
+lseek(11, 0, SEEK_CUR)                  = 0
+fstat(11, {st_dev=makedev(9, 3), st_ino=1358995409, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2985, st_atime=2010/05/18-14:09:01, st_mtime=2010/05/05-14:08:52, st_ctime=2010/05/05-14:08:52}) = 0
+mmap(NULL, 2985, PROT_READ, MAP_SHARED, 11, 0) = 0x7f6d12ffe000
+lseek(11, 2985, SEEK_SET)               = 2985
+fstat(11, {st_dev=makedev(9, 3), st_ino=1358995409, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2985, st_atime=2010/05/18-14:09:01, st_mtime=2010/05/05-14:08:52, st_ctime=2010/05/05-14:08:52}) = 0
+munmap(0x7f6d12ffe000, 2985)            = 0
+close(11)                               = 0
+rt_sigaction(SIGPIPE, {0x1, [], SA_RESTORER, 0x7f6d120ed560}, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d120ed560}, 8) = 0
+stat("/etc/ldap.conf", {st_dev=makedev(9, 3), st_ino=1357234870, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9554, st_atime=2010/05/18-01:30:01, st_mtime=2010/05/13-01:29:36, st_ctime=2010/05/13-01:29:37}) = 0
+geteuid()                               = 0
+getsockname(10, {sa_family=AF_INET6, sin6_port=htons(60020), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+getpeername(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+stat("/etc/ldap.conf", {st_dev=makedev(9, 3), st_ino=1357234870, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=24, st_size=9554, st_atime=2010/05/18-01:30:01, st_mtime=2010/05/13-01:29:36, st_ctime=2010/05/13-01:29:37}) = 0
+geteuid()                               = 0
+getsockname(10, {sa_family=AF_INET6, sin6_port=htons(60020), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+getpeername(10, {sa_family=AF_INET6, sin6_port=htons(389), inet_pton(AF_INET6, "::1", &sin6_addr), sin6_flowinfo=0, sin6_scope_id=0}, [28]) = 0
+write(10, "0\201\274\2\1\3c\201\266\4\17ou=users,o=borg\n\1\2\n\1\0"..., 191) = 191
+poll([{fd=10, events=POLLIN|POLLPRI|POLLERR|POLLHUP}], 1, 5000) = 1 ([{fd=10, revents=POLLIN}])
+read(10, "0\f\2\1\3e\7\n", 8)           = 8
+read(10, "\1\0\4\0\4\0", 6)             = 6
+rt_sigaction(SIGPIPE, {0x7f6d1285c980, [], SA_RESTORER|SA_SIGINFO, 0x7f6d120ed560}, NULL, 8) = 0
+write(2, "warning: ", 9)                = 9
+write(2, "user sys does not exist - using "..., 37) = 37
+open("/test;4bf2885b", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 11
+fcntl(11, F_SETFD, FD_CLOEXEC)          = 0
+close(11)                               = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "                                "..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "                    ( 49%)\10\10\10\10\10\10"..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "%)\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10"..., 152) = 152
+rename("/test;4bf2885b", "/test")       = 0
+getuid()                                = 0
+getuid()                                = 0
+chown("/test", 0, 0)                    = 0
+chmod("/test", 0644)                    = 0
+utime("/test", [2010/05/18-14:29:40, 2010/05/18-14:29:40]) = 0
+munmap(0x7f6d0cdad000, 67112960)        = 0
+close(9)                                = 0
+munmap(0x7f6d13001000, 4096)            = 0
+munmap(0x7f6d12fff000, 8192)            = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "######################          "..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "########            (100%)\10\10\10\10\10\10"..., 1024) = 1024
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "%)\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10\10"..., 152) = 152
+ioctl(1, SNDCTL_TMR_TIMEBASE or TCGETS, {c_iflags=0x2500, c_oflags=0x5, c_cflags=0xbf, c_lflags=0x8a3b, c_line=0, c_cc="\x03\x1c\x7f\x15\x04\x00\x01\x00\x11\x13\x1a\x00\x12\x0f\x17\x16\x00\x00\x00"}) = 0
+write(1, "################################"..., 51) = 51
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_BLOCK, ~[HUP INT QUIT PIPE TERM RTMIN RT_1], NULL, 8) = 0
+pread(3, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\10\1C\7\0\2\373\17\366\17\361\17"..., 4096, 4096) = 4096
+pwrite(3, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\10\1C\7\0\2\373\17\366\17\361\17"..., 4096, 4096) = 4096
+fdatasync(3)                            = 0
+pread(3, "\0\0\0\0\1\0\0\0/\n\0\0\0\0\0\0\341\30\0\0~\1Q\3\0\2\373\17\357\17\352\17"..., 4096, 10678272) = 4096
+pread(3, "\0\0\0\0\1\0\0\0\341\30\0\0/\n\0\0\0\0\0\0\222\0'\v\0\2\373\17\357\17\352\17"..., 4096, 26087424) = 4096
+pread(3, "\0\0\0\0\1\0\0\0\377\20\0\0\0\0\0\0\376\20\0\0\0\0\0\20\0\0\0\0\0003\0\0"..., 4096, 17821696) = 4096
+pwrite(3, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\376\20\0\0"..., 4096, 0) = 4096
+pwrite(3, "\0\0\0\0\1\0\0\0/\n\0\0\0\0\0\0\341\30\0\0\200\1@\3\0\2\373\17\357\17\352\17"..., 4096, 10678272) = 4096
+pwrite(3, "\0\0\0\0\1\0\0\0\377\20\0\0\0\0\0\0\0\0\0\0\1\0h\5\0\7\0\0\0003\0\0"..., 4096, 17821696) = 4096
+fdatasync(3)                            = 0
+fdatasync(3)                            = 0
+pwrite(4, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 4096, 0) = 4096
+pwrite(4, "\0\0\0\0\1\0\0\0\v\0\0\0\5\0\0\0\0\0\0\0\300\0x\7\0\2\353\17\342\17\326\17"..., 4096, 45056) = 4096
+pwrite(5, "\0\0\0\0\1\0\0\0\316\1\0\0\0\0\0\0\0\0\0\0\342\0\202\4\0\2\361\17\340\17\312\17"..., 4096, 1892352) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Group", {st_dev=makedev(9, 3), st_ino=3779703666, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=64, st_size=32768, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Group", O_RDWR)      = 9
+fcntl(9, F_SETFD, FD_CLOEXEC)           = 0
+read(9, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 512) = 512
+close(9)                                = 0
+open("/var/lib/rpm/Group", O_RDWR)      = 9
+fcntl(9, F_SETFD, FD_CLOEXEC)           = 0
+fstat(9, {st_dev=makedev(9, 3), st_ino=3779703666, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=64, st_size=32768, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(9, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 4096, 0) = 4096
+pread(9, "\0\0\0\0\1\0\0\0\5\0\0\0\0\0\0\0\7\0\0\0H\0\353\7\0\2\357\17\256\17\216\17"..., 4096, 20480) = 4096
+pread(9, "\0\0\0\0\1\0\0\0\7\0\0\0\5\0\0\0\0\0\0\0\6\0\237\f\0\2\336\17\325\17\265\17"..., 4096, 28672) = 4096
+pwrite(9, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\3\0\0\0"..., 4096, 0) = 4096
+pwrite(9, "\0\0\0\0\1\0\0\0\5\0\0\0\0\0\0\0\7\0\0\0J\0\337\7\0\2\357\17\256\17\216\17"..., 4096, 20480) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Requirename", {st_dev=makedev(9, 3), st_ino=3779703674, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=464, st_size=233472, st_atime=2010/05/18-14:29:57, st_mtime=2010/05/18-10:57:02, st_ctime=2010/05/18-10:57:02}) = 0
+open("/var/lib/rpm/Requirename", O_RDWR) = 11
+fcntl(11, F_SETFD, FD_CLOEXEC)          = 0
+read(11, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0,\0\0\0"..., 512) = 512
+close(11)                               = 0
+open("/var/lib/rpm/Requirename", O_RDWR) = 11
+fcntl(11, F_SETFD, FD_CLOEXEC)          = 0
+fstat(11, {st_dev=makedev(9, 3), st_ino=3779703674, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=464, st_size=233472, st_atime=2010/05/18-14:29:57, st_mtime=2010/05/18-10:57:02, st_ctime=2010/05/18-10:57:02}) = 0
+pread(11, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0,\0\0\0"..., 4096, 0) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Providename", {st_dev=makedev(9, 3), st_ino=3779703677, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=2096, st_size=1290240, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Providename", O_RDWR) = 12
+fcntl(12, F_SETFD, FD_CLOEXEC)          = 0
+read(12, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\233\0\0\0"..., 512) = 512
+close(12)                               = 0
+open("/var/lib/rpm/Providename", O_RDWR) = 12
+fcntl(12, F_SETFD, FD_CLOEXEC)          = 0
+fstat(12, {st_dev=makedev(9, 3), st_ino=3779703677, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=2096, st_size=1290240, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(12, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\233\0\0\0"..., 4096, 0) = 4096
+pread(12, "\0\0\0\0\1\0\0\0\202\0\0\0\0\0\0\0\225\0\0\0\272\0\237\1\0\2\356\17\345\17\324\17"..., 4096, 532480) = 4096
+pread(12, "\0\0\0\0\1\0\0\0\225\0\0\0\202\0\0\0\0\0\0\0\212\0\n\6\0\2\330\17\317\17\246\17"..., 4096, 610304) = 4096
+pread(12, "\0\0\0\0\1\0\0\0\37\0\0\0\0\0\0\0\0\0\0\0\272\0\\\2\0\2\365\17\354\17\326\17"..., 4096, 126976) = 4096
+pwrite(12, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\233\0\0\0"..., 4096, 0) = 4096
+pwrite(12, "\0\0\0\0\1\0\0\0\37\0\0\0\0\0\0\0\0\0\0\0\274\0H\2\0\2\365\17\354\17\326\17"..., 4096, 126976) = 4096
+pwrite(12, "\0\0\0\0\1\0\0\0\202\0\0\0\0\0\0\0\225\0\0\0\274\0\223\1\0\2\356\17\345\17\324\17"..., 4096, 532480) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Dirnames", {st_dev=makedev(9, 3), st_ino=3779703887, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=4200, st_size=2150400, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Dirnames", O_RDWR)   = 13
+fcntl(13, F_SETFD, FD_CLOEXEC)          = 0
+read(13, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 512) = 512
+close(13)                               = 0
+open("/var/lib/rpm/Dirnames", O_RDWR)   = 13
+fcntl(13, F_SETFD, FD_CLOEXEC)          = 0
+fstat(13, {st_dev=makedev(9, 3), st_ino=3779703887, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=4200, st_size=2150400, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(13, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(13, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\f\0000\r\3\3\364\17\324\17\250\17"..., 4096, 4096) = 4096
+pread(13, "\0\0\0\0\1\0\0\0P\0\0\0\0\0\0\0\0\0\0\0/\0\20\7\2\3\364\17\230\7(\10"..., 4096, 327680) = 4096
+pread(13, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0002\1\0\0006\0d\v\1\5\374\17\360\17\350\17"..., 4096, 8192) = 4096
+pwrite(13, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0002\1\0\0006\0\\\v\1\5\374\17\350\17\340\17"..., 4096, 8192) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Requireversion", {st_dev=makedev(9, 3), st_ino=3779704814, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=328, st_size=167936, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Requireversion", O_RDWR) = 14
+fcntl(14, F_SETFD, FD_CLOEXEC)          = 0
+read(14, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 512) = 512
+close(14)                               = 0
+open("/var/lib/rpm/Requireversion", O_RDWR) = 14
+fcntl(14, F_SETFD, FD_CLOEXEC)          = 0
+fstat(14, {st_dev=makedev(9, 3), st_ino=3779704814, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=328, st_size=167936, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(14, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\6\0\240\17\2\3\364\17\300\17\340\17"..., 4096, 4096) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\35\0\0\0\5\0\0\0\6\0\0\0\242\0@\6\1\5\370\17\314\17\300\17"..., 4096, 118784) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\25\0\0\0\0\0\0\0\7\0\0\0\1\0\346\17\0\7\1\0\0\0\2\0"..., 4096, 86016) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\7\0\0\0\25\0\0\0&\0\0\0\1\0\346\17\0\7\0\0\25\2\0\0"..., 4096, 28672) = 4096
+pread(14, "\0\0\0\0\1\0\0\0&\0\0\0\7\0\0\0\0\0\0\0\1\0\204\0\0\7\3\0\0\0%\4"..., 4096, 155648) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\10\0\0\0\0\0\0\0\26\0\0\0\1\0\346\17\0\7\1\0\0\0\3\0"..., 4096, 32768) = 4096
+pread(14, "\0\0\0\0\1\0\0\0\26\0\0\0\10\0\0\0'\0\0\0\1\0\346\17\0\7\0\0\25\2\0\0"..., 4096, 90112) = 4096
+pread(14, "\0\0\0\0\1\0\0\0'\0\0\0\26\0\0\0\0\0\0\0\1\0\204\0\0\7\4\0\0\0%\4"..., 4096, 159744) = 4096
+pread(14, "\0\0\0\0\1\0\0\0(\0\0\0\6\0\0\0\21\0\0\0L\0<\t\1\5\370\17L\rD\r"..., 4096, 163840) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 4096, 0) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\7\0\0\0&\0\0\0\25\0\0\0\1\0\346\17\0\7\0\0\25\2\0\0"..., 4096, 28672) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\10\0\0\0\26\0\0\0\0\0\0\0\1\0\214\0\0\7\4\0\0\0%\4"..., 4096, 32768) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\25\0\0\0\7\0\0\0\0\0\0\0\1\0\214\0\0\7\3\0\0\0%\4"..., 4096, 86016) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\26\0\0\0'\0\0\0\10\0\0\0\1\0\346\17\0\7\0\0\25\2\0\0"..., 4096, 90112) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0\35\0\0\0\5\0\0\0\6\0\0\0\242\0@\6\1\5\370\17\314\17\300\17"..., 4096, 118784) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0&\0\0\0\0\0\0\0\7\0\0\0\1\0\346\17\0\7\1\0\0\0\2\0"..., 4096, 155648) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0'\0\0\0\0\0\0\0\26\0\0\0\1\0\346\17\0\7\1\0\0\0\3\0"..., 4096, 159744) = 4096
+pwrite(14, "\0\0\0\0\1\0\0\0(\0\0\0\6\0\0\0\21\0\0\0L\0004\t\1\5\370\17D\r<\r"..., 4096, 163840) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Provideversion", {st_dev=makedev(9, 3), st_ino=3779704822, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=1088, st_size=557056, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Provideversion", O_RDWR) = 15
+fcntl(15, F_SETFD, FD_CLOEXEC)          = 0
+read(15, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 512) = 512
+close(15)                               = 0
+open("/var/lib/rpm/Provideversion", O_RDWR) = 15
+fcntl(15, F_SETFD, FD_CLOEXEC)          = 0
+fstat(15, {st_dev=makedev(9, 3), st_ino=3779704822, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=1088, st_size=557056, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(15, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(15, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0z\0,\10\2\3\364\17\230\10T\t"..., 4096, 4096) = 4096
+pread(15, "\0\0\0\0\1\0\0\0\3\0\0\0\0\0\0\0~\0\0\0\222\0\224\3\1\5\374\17\224\3\360\17"..., 4096, 12288) = 4096
+pwrite(15, "\0\0\0\0\1\0\0\0\3\0\0\0\0\0\0\0~\0\0\0\224\0x\3\1\5\374\17\224\3\360\17"..., 4096, 12288) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Installtid", {st_dev=makedev(9, 3), st_ino=3779704823, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=80, st_size=40960, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Installtid", O_RDWR) = 16
+fcntl(16, F_SETFD, FD_CLOEXEC)          = 0
+read(16, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 512) = 512
+close(16)                               = 0
+open("/var/lib/rpm/Installtid", O_RDWR) = 16
+fcntl(16, F_SETFD, FD_CLOEXEC)          = 0
+fstat(16, {st_dev=makedev(9, 3), st_ino=3779704823, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=80, st_size=40960, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(16, "\0\0\0\0\1\0\0\0\0\0\0\0b1\5\0\t\0\0\0\0\20\0\0\0\t\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(16, "\0\0\0\0\1\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\10\0\204\17\2\3\364\17\224\17\324\17"..., 4096, 4096) = 4096
+pread(16, "\0\0\0\0\1\0\0\0\4\0\0\0\10\0\0\0\7\0\0\0\260\0\320\7\1\5\370\17\354\17\344\17"..., 4096, 16384) = 4096
+pwrite(16, "\0\0\0\0\1\0\0\0\4\0\0\0\10\0\0\0\7\0\0\0\262\0\274\7\1\5\370\17\354\17\344\17"..., 4096, 16384) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Sigmd5", {st_dev=makedev(9, 3), st_ino=3779704827, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=136, st_size=77824, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Sigmd5", O_RDWR)     = 17
+fcntl(17, F_SETFD, FD_CLOEXEC)          = 0
+read(17, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 512) = 512
+close(17)                               = 0
+open("/var/lib/rpm/Sigmd5", O_RDWR)     = 17
+fcntl(17, F_SETFD, FD_CLOEXEC)          = 0
+fstat(17, {st_dev=makedev(9, 3), st_ino=3779704827, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=136, st_size=77824, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(17, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(17, "\0\0\0\0\1\0\0\0\6\0\0\0\0\0\0\0\n\0\0\0\16\1J\2\0\2\357\17\346\17\325\17"..., 4096, 24576) = 4096
+pread(17, "\0\0\0\0\1\0\0\0\n\0\0\0\6\0\0\0\0\0\0\0 \0`\16\0\2\357\17\346\17\325\17"..., 4096, 40960) = 4096
+pwrite(17, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pwrite(17, "\0\0\0\0\1\0\0\0\n\0\0\0\6\0\0\0\0\0\0\0\"\0F\16\0\2\357\17\346\17\325\17"..., 4096, 40960) = 4096
+brk(0x228b000)                          = 0x228b000
+brk(0x2287000)                          = 0x2287000
+brk(0x2283000)                          = 0x2283000
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Sha1header", {st_dev=makedev(9, 3), st_ino=3779704828, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=160, st_size=90112, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Sha1header", O_RDWR) = 18
+fcntl(18, F_SETFD, FD_CLOEXEC)          = 0
+read(18, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\24\0\0\0"..., 512) = 512
+close(18)                               = 0
+open("/var/lib/rpm/Sha1header", O_RDWR) = 18
+fcntl(18, F_SETFD, FD_CLOEXEC)          = 0
+fstat(18, {st_dev=makedev(9, 3), st_ino=3779704828, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=160, st_size=90112, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(18, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\24\0\0\0"..., 4096, 0) = 4096
+pread(18, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0\0\0\0\0\222\0\276\1\0\2\327\17\316\17\245\17"..., 4096, 8192) = 4096
+pwrite(18, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\24\0\0\0"..., 4096, 0) = 4096
+pwrite(18, "\0\0\0\0\1\0\0\0\2\0\0\0\0\0\0\0\0\0\0\0\224\0\214\1\0\2\327\17\316\17\245\17"..., 4096, 8192) = 4096
+getgid()                                = 0
+getuid()                                = 0
+stat("/var", {st_dev=makedev(9, 3), st_ino=1073741953, st_mode=S_IFDIR|0755, st_nlink=14, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:30, st_mtime=2010/02/26-11:36:45, st_ctime=2010/02/26-11:36:45}) = 0
+stat("/var/lib", {st_dev=makedev(9, 3), st_ino=3507401633, st_mode=S_IFDIR|0755, st_nlink=57, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/17-19:19:39, st_ctime=2010/05/17-19:19:39}) = 0
+stat("/var/lib/rpm", {st_dev=makedev(9, 3), st_ino=1359243633, st_mode=S_IFDIR|0755, st_nlink=3, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=4096, st_atime=2010/05/17-19:19:32, st_mtime=2010/05/15-08:15:52, st_ctime=2010/05/15-08:15:52}) = 0
+access("/var/lib/rpm", W_OK)            = 0
+access("/var/lib/rpm/__db.001", F_OK)   = -1 ENOENT (No such file or directory)
+stat("/var/lib/rpm/Filedigests", {st_dev=makedev(9, 3), st_ino=3779704833, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=11968, st_size=10002432, st_atime=2010/05/18-14:30:18, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+open("/var/lib/rpm/Filedigests", O_RDWR) = 19
+fcntl(19, F_SETFD, FD_CLOEXEC)          = 0
+read(19, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 512) = 512
+close(19)                               = 0
+open("/var/lib/rpm/Filedigests", O_RDWR) = 19
+fcntl(19, F_SETFD, FD_CLOEXEC)          = 0
+fstat(19, {st_dev=makedev(9, 3), st_ino=3779704833, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=11968, st_size=10002432, st_atime=2010/05/18-14:30:19, st_mtime=2010/05/18-14:30:18, st_ctime=2010/05/18-14:30:18}) = 0
+pread(19, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pread(19, "\0\0\0\0\1\0\0\0,\4\0\0\0\0\0\0002\5\0\0\366\0\377\2\0\2\357\17\346\17\325\17"..., 4096, 4374528) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\27\5\0\0\0\0\0\0\25\5\0\0\1\0\346\17\0\7\3\0\0\0\4\0"..., 4096, 5337088) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\25\5\0\0\27\5\0\0\22\5\0\0\1\0\346\17\0\7\0\0\304\2\0\0"..., 4096, 5328896) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\22\5\0\0\25\5\0\0o\2\0\0\1\0\346\17\0\7\304\4\0\0\304\2"..., 4096, 5316608) = 4096
+pread(19, "\0\0\0\0\1\0\0\0o\2\0\0\22\5\0\0\f\5\0\0\1\0\346\17\0\7\0\0\245\7\0\0"..., 4096, 2551808) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\f\5\0\0o\2\0\0\t\5\0\0\1\0\346\17\0\7\304\2\0\0]\n"..., 4096, 5292032) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\t\5\0\0\f\5\0\0\363\4\0\0\1\0\346\17\0\7\0\0\304\2\0\0"..., 4096, 5279744) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\363\4\0\0\t\5\0\0\v\0\0\0\1\0\346\17\0\7\234\17\0\0\304\2"..., 4096, 5189632) = 4096
+brk(0x22a4000)                          = 0x22a4000
+pread(19, "\0\0\0\0\1\0\0\0\v\0\0\0\363\4\0\0\n\5\0\0\1\0\346\17\0\7\0\0H\22\0\0"..., 4096, 45056) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\n\5\0\0\v\0\0\0\v\5\0\0\1\0\346\17\0\7\"\3\0\0\25\1"..., 4096, 5283840) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\v\5\0\0\n\5\0\0\r\5\0\0\1\0\346\17\0\7\0\0\"\3\0\0"..., 4096, 5287936) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\r\5\0\0\v\5\0\0\16\5\0\0\1\0\346\17\0\7\277\6\0\0\"\3"..., 4096, 5296128) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\16\5\0\0\r\5\0\0\21\5\0\0\1\0\346\17\0\7\0\0\220\t\0\0"..., 4096, 5300224) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\21\5\0\0\16\5\0\0\23\5\0\0\1\0\346\17\0\7\"\3\0\0003\f"..., 4096, 5312512) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\23\5\0\0\21\5\0\0\24\5\0\0\1\0\346\17\0\7\0\0\"\3\0\0"..., 4096, 5320704) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\24\5\0\0\23\5\0\0\26\5\0\0\1\0\346\17\0\7\214\21\0\0\"\3"..., 4096, 5324800) = 4096
+pread(19, "\0\0\0\0\1\0\0\0\26\5\0\0\24\5\0\0\0\0\0\0\1\0\326\1\0\7\0\0B\24\0\0"..., 4096, 5332992) = 4096
+brk(0x22cb000)                          = 0x22cb000
+brk(0x22bc000)                          = 0x22bc000
+brk(0x22ac000)                          = 0x22ac000
+pwrite(19, "\0\0\0\0\1\0\0\0\0\0\0\0a\25\6\0\10\0\0\0\0\20\0\0\0\10\0\0\0\0\0\0"..., 4096, 0) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\v\0\0\0\n\5\0\0\363\4\0\0\1\0\346\17\0\7\"\3\0\0\25\1"..., 4096, 45056) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0o\2\0\0\f\5\0\0\22\5\0\0\1\0\346\17\0\7\"\3\0\0003\f"..., 4096, 2551808) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0,\4\0\0\0\0\0\0002\5\0\0\366\0\377\2\0\2\357\17\346\17\325\17"..., 4096, 4374528) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\363\4\0\0\v\0\0\0\t\5\0\0\1\0\346\17\0\7\0\0\"\3\0\0"..., 4096, 5189632) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\t\5\0\0\363\4\0\0\f\5\0\0\1\0\346\17\0\7\277\6\0\0\"\3"..., 4096, 5279744) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\n\5\0\0\v\5\0\0\v\0\0\0\1\0\346\17\0\7\0\0H\22\0\0"..., 4096, 5283840) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\v\5\0\0\r\5\0\0\n\5\0\0\1\0\346\17\0\7\234\17\0\0\304\2"..., 4096, 5287936) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\f\5\0\0\t\5\0\0o\2\0\0\1\0\346\17\0\7\0\0\220\t\0\0"..., 4096, 5292032) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\r\5\0\0\16\5\0\0\v\5\0\0\1\0\346\17\0\7\0\0\304\2\0\0"..., 4096, 5296128) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\16\5\0\0\21\5\0\0\r\5\0\0\1\0\346\17\0\7\304\2\0\0]\n"..., 4096, 5300224) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\21\5\0\0\23\5\0\0\16\5\0\0\1\0\346\17\0\7\0\0\245\7\0\0"..., 4096, 5312512) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\22\5\0\0o\2\0\0\25\5\0\0\1\0\346\17\0\7\0\0\"\3\0\0"..., 4096, 5316608) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\23\5\0\0\24\5\0\0\21\5\0\0\1\0\346\17\0\7\304\4\0\0\304\2"..., 4096, 5320704) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\24\5\0\0\26\5\0\0\23\5\0\0\1\0\346\17\0\7\0\0\304\2\0\0"..., 4096, 5324800) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\25\5\0\0\22\5\0\0\27\5\0\0\1\0\346\17\0\7\214\21\0\0\"\3"..., 4096, 5328896) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\26\5\0\0\0\0\0\0\24\5\0\0\1\0\346\17\0\7\3\0\0\0\4\0"..., 4096, 5332992) = 4096
+pwrite(19, "\0\0\0\0\1\0\0\0\27\5\0\0\25\5\0\0\0\0\0\0\1\0\336\1\0\7\0\0B\24\0\0"..., 4096, 5337088) = 4096
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], ~[KILL STOP RTMIN RT_1], 8) = 0
+rt_sigprocmask(SIG_SETMASK, ~[KILL STOP RTMIN RT_1], NULL, 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+rt_sigprocmask(SIG_BLOCK, ~[RTMIN RT_1], [], 8) = 0
+rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
+close(7)                                = 0
+fdatasync(3)                            = 0
+fcntl(6, F_SETLK, {type=F_UNLCK, whence=SEEK_SET, start=0, len=0}) = 0
+close(6)                                = 0
+close(19)                               = 0
+close(18)                               = 0
+close(17)                               = 0
+close(16)                               = 0
+close(15)                               = 0
+close(14)                               = 0
+close(13)                               = 0
+close(8)                                = 0
+close(12)                               = 0
+close(11)                               = 0
+close(9)                                = 0
+close(5)                                = 0
+close(4)                                = 0
+fdatasync(3)                            = 0
+close(3)                                = 0
+open("/var/lib/rpm/Packages", O_RDWR)   = 3
+fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
+fdatasync(3)                            = 0
+close(3)                                = 0
+brk(0x22a4000)                          = 0x22a4000
+brk(0x22a3000)                          = 0x22a3000
+brk(0x22a0000)                          = 0x22a0000
+brk(0x228d000)                          = 0x228d000
+rt_sigaction(SIGHUP, {SIG_DFL, [], SA_RESTORER, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigaction(SIGINT, {SIG_DFL, [], SA_RESTORER, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigaction(SIGTERM, {SIG_DFL, [], SA_RESTORER, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigaction(SIGQUIT, {SIG_DFL, [], SA_RESTORER, 0x7f6d12424c00}, NULL, 8) = 0
+rt_sigaction(SIGPIPE, {SIG_DFL, [], SA_RESTORER, 0x7f6d12424c00}, NULL, 8) = 0
+exit_group(0)                           = ?

--- a/attachment/ticket/157/ts.spec
+++ b/attachment/ticket/157/ts.spec
@@ -1,0 +1,17 @@
+
+Name:	ts
+Summary: ts
+Version:	0
+Release:	0
+Group:	ts
+License: ts
+
+%description
+
+%install
+mkdir -p "%buildroot";
+touch "%buildroot/test";
+
+%files
+%defattr(-,sys,root)
+/test

--- a/attachment/ticket/39/eclipse.spec.patch
+++ b/attachment/ticket/39/eclipse.spec.patch
@@ -1,0 +1,67 @@
+--- eclipse.spec	12 Feb 2009 20:05:15 -0000	1.608
++++ eclipse.spec	5 Mar 2009 18:36:11 -0000
+@@ -1,3 +1,5 @@
++%define __find_requires /usr/lib/rpm/osgideps.pl -r
++
+ # TODO:
+ # - update ecj-rpmdebuginfo patch
+ # - look at startup script and launcher patches
+@@ -1381,6 +1383,15 @@
+ %{_libdir}/%{name}/plugins/org.eclipse.ui.workbench_*
+ %{_libdir}/%{name}/plugins/org.eclipse.update.configurator_*
+ %{_libdir}/%{name}/plugins/org.eclipse.equinox.simpleconfigurator_*
++%{_libdir}/%{name}/plugins/javax.servlet_*
++%{_libdir}/%{name}/plugins/javax.servlet.jsp_*
++%{_libdir}/%{name}/plugins/org.eclipse.core.resources_*
++%{_libdir}/%{name}/plugins/org.eclipse.core.resources.compatibility_*
++%{_libdir}/%{name}/plugins/org.eclipse.text_*
++%{_libdir}/%{name}/plugins/org.eclipse.team.core_*
++%{_libdir}/%{name}/plugins/org.eclipse.ant.core_*
++%{_libdir}/%{name}/plugins/org.eclipse.core.variables_*
++%{_libdir}/%{name}/plugins/org.eclipse.osgi.services_*
+ 
+ %if %{initialize}
+ %files platform -f %{name}-platform.install
+@@ -1400,14 +1411,11 @@
+ %dir %{_datadir}/%{name}/dropins
+ %{_libdir}/%{name}/features/org.eclipse.platform_*
+ %{_libdir}/%{name}/plugins/com.jcraft.jsch_*
+-%{_libdir}/%{name}/plugins/javax.servlet_*
+-%{_libdir}/%{name}/plugins/javax.servlet.jsp_*
+ %{_libdir}/%{name}/plugins/org.apache.ant_*
+ %{_libdir}/%{name}/plugins/org.apache.commons.el_*
+ %{_libdir}/%{name}/plugins/org.apache.commons.logging_*
+ %{_libdir}/%{name}/plugins/org.apache.lucene_*
+ %{_libdir}/%{name}/plugins/org.apache.lucene.analysis_*
+-%{_libdir}/%{name}/plugins/org.eclipse.ant.core_*
+ %{_libdir}/%{name}/plugins/org.eclipse.compare_*
+ %{_libdir}/%{name}/plugins/org.eclipse.core.boot_*
+ %{_libdir}/%{name}/plugins/org.eclipse.core.filebuffers_*
+@@ -1419,11 +1427,8 @@
+ %ifarch %{ix86}
+ %{_libdir}/%{name}/plugins/org.eclipse.core.net.linux.x86_*
+ %endif
+-%{_libdir}/%{name}/plugins/org.eclipse.core.resources_*
+-%{_libdir}/%{name}/plugins/org.eclipse.core.resources.compatibility_*
+ %{_libdir}/%{name}/plugins/org.eclipse.core.runtime.compatibility_*
+ %{_libdir}/%{name}/plugins/org.eclipse.core.runtime.compatibility.registry_*
+-%{_libdir}/%{name}/plugins/org.eclipse.core.variables_*
+ %{_libdir}/%{name}/plugins/org.eclipse.debug.core_*
+ %{_libdir}/%{name}/plugins/org.eclipse.debug.ui_*
+ %{_libdir}/%{name}/plugins/org.eclipse.equinox.http.jetty_*
+@@ -1440,14 +1445,11 @@
+ %{_libdir}/%{name}/plugins/org.eclipse.jsch.ui_*
+ %{_libdir}/%{name}/plugins/org.eclipse.ltk.core.refactoring_*
+ %{_libdir}/%{name}/plugins/org.eclipse.ltk.ui.refactoring_*
+-%{_libdir}/%{name}/plugins/org.eclipse.osgi.services_*
+ %{_libdir}/%{name}/plugins/org.eclipse.osgi.util_*
+ %{_libdir}/%{name}/plugins/org.eclipse.platform_*
+ %{_libdir}/%{name}/plugins/org.eclipse.platform.doc.user_*
+ %{_libdir}/%{name}/plugins/org.eclipse.search_*
+-%{_libdir}/%{name}/plugins/org.eclipse.team.core_*
+ %{_libdir}/%{name}/plugins/org.eclipse.team.ui_*
+-%{_libdir}/%{name}/plugins/org.eclipse.text_*
+ %{_libdir}/%{name}/plugins/org.eclipse.ui.browser_*
+ %{_libdir}/%{name}/plugins/org.eclipse.ui.cheatsheets_*
+ %{_libdir}/%{name}/plugins/org.eclipse.ui.console_*
+

--- a/attachment/ticket/39/osgideps.pl-2009-02-03.patch
+++ b/attachment/ticket/39/osgideps.pl-2009-02-03.patch
@@ -1,0 +1,128 @@
+diff --git a/scripts/osgideps.pl b/scripts/osgideps.pl
+index 7b02016..428a82f 100644
+--- a/scripts/osgideps.pl
++++ b/scripts/osgideps.pl
+@@ -1,14 +1,12 @@
+ #!/usr/bin/perl
+ 
+-
+ use Cwd;
+ use Getopt::Long;
+-
++use File::Temp qw/ tempdir /;
+ 
+ $cdir = getcwd();
+-$TEMPDIR="/tmp";
+-$MANIFEST_NAME="META-INF/MANIFEST.MF";
+-
++$TEMPDIR = tempdir($template, CLEANUP => 1);
++$MANIFEST_NAME = "META-INF/MANIFEST.MF";
+ 
+ # prepare temporary directory
+ if (! (-d $TEMPDIR)) {
+@@ -18,29 +16,21 @@ if (! (-d $TEMPDIR)) {
+ 
+ # parse options
+ my ($show_provides, $show_requires);
+-
+ my $result = GetOptions("provides" => \$show_provides,
+-			"requires" => \$show_requires);
+-
++		"requires" => \$show_requires);
+ exit(1) if (not $result);
+ 
+-
+-
++# run selected sub
+ @allfiles = <STDIN>;
+-
+ if ($show_provides) {
+ 	do_provides(@allfiles);
+ }
+-
+ if ($show_requires) {
+ 	do_requires(@allfiles);
+ }
+-
+-
+ exit(0);
+ 
+ 
+-
+ sub do_provides {
+ 
+ foreach $file (@_) {
+@@ -55,7 +45,7 @@ foreach $file (@_) {
+ 	        	        chdir $TEMPDIR;
+ 			        `jar xf $file $MANIFEST_NAME`;	
+ 		               	open(MANIFEST, "$MANIFEST_NAME");
+-				chdir $cdir;
++ 				chdir $cdir;
+ 			}
+ 	        } else  {
+ 			open(MANIFEST, "$file");
+@@ -100,8 +90,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ 
+@@ -121,7 +110,7 @@ sub do_requires {
+ 					open(MANIFEST, "$MANIFEST_NAME");
+ 					chdir $cdir;
+ 				}
+-			} else  {
++			} else {
+ 				open(MANIFEST, "$file");
+ 			}
+        			my %reqcomp = ();
+@@ -146,8 +135,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ sub parsePkgString {
+@@ -157,6 +145,8 @@ sub parsePkgString {
+         $bunstr =~ s/\n//g;
+         $bunstr =~ s/[^[:print:]]//g;
+         $bunstr =~ s/("[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+)(,)([[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+")/$1 $3/g;
++	# Remove uses bundle from Export-Package props	
++	$bunstr =~ s/uses:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
+         @reqcomp = split /,/g, $bunstr;
+         foreach $reqelement (@reqcomp) {
+                 @reqelementfrmnt = split /;/g, $reqelement;
+@@ -183,11 +173,13 @@ sub parseVersion {
+         my $ver = $_[0];
+         if ($ver eq "") { return "";}
+         if ($ver =~ m/(^[\[|\(])(.+)\ (.+)([\]|\)]$)/) {
+-		# FIXME: The right rpm match of osgi version [1,2) seems to be <= 2
++		# FIXME: The right RPM match of osgi version [1,2) seems to be <= 2
+ 		# but when you look at the requires >= look more permssive/correct?
+ 		($1 eq "\[") ? return " >= $2" : return " > $2";
+         } else {
+-                return " = $ver";
++		# FIXME: Same here, equal seem to be the correct version match operation but Eclipse 
++		# OSGI implementation seem to be permissive about version check.
++                return " >= $ver";
+         }
+         return $ver;
+ }
+@@ -196,8 +188,8 @@ sub fixVersion {
+         my $version = $_[0];
+ 	# remove version qualifier.
+ 	$version =~ s/\.v.[0-9]*.*//g;
+-	# We try to match RPM version, so remove last .0
+-	$version =~ s/\.0$//g;
++	# rpm don't manage .0 at the end of the version string like OSGI do. 
++	$version =~ s/[0|\.]*$//g;
+ 	return $version;
+ }
+ 

--- a/attachment/ticket/39/osgideps.pl.2.patch
+++ b/attachment/ticket/39/osgideps.pl.2.patch
@@ -1,0 +1,137 @@
+diff --git a/scripts/osgideps.pl b/scripts/osgideps.pl
+index 7b02016..0f73724 100644
+--- a/scripts/osgideps.pl
++++ b/scripts/osgideps.pl
+@@ -1,14 +1,12 @@
+ #!/usr/bin/perl
+ 
+-
+ use Cwd;
+ use Getopt::Long;
+-
++use File::Temp qw/ tempdir /;
+ 
+ $cdir = getcwd();
+-$TEMPDIR="/tmp";
+-$MANIFEST_NAME="META-INF/MANIFEST.MF";
+-
++$TEMPDIR = tempdir($template, CLEANUP => 1);
++$MANIFEST_NAME = "META-INF/MANIFEST.MF";
+ 
+ # prepare temporary directory
+ if (! (-d $TEMPDIR)) {
+@@ -18,29 +16,21 @@ if (! (-d $TEMPDIR)) {
+ 
+ # parse options
+ my ($show_provides, $show_requires);
+-
+ my $result = GetOptions("provides" => \$show_provides,
+-			"requires" => \$show_requires);
+-
++		"requires" => \$show_requires);
+ exit(1) if (not $result);
+ 
+-
+-
++# run selected sub
+ @allfiles = <STDIN>;
+-
+ if ($show_provides) {
+ 	do_provides(@allfiles);
+ }
+-
+ if ($show_requires) {
+ 	do_requires(@allfiles);
+ }
+-
+-
+ exit(0);
+ 
+ 
+-
+ sub do_provides {
+ 
+ foreach $file (@_) {
+@@ -71,7 +61,6 @@ foreach $file (@_) {
+                 	}
+ 	                if (m/(^Bundle-Version: )(.*)/) {
+ 				$version = $2;
+-				$version = fixVersion($version);
+ 			}
+ 		        if (m/(^(Export-Package): )(.*)$/) {
+ 	        		my $bunlist = "$3"."\n";
+@@ -100,8 +89,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ 
+@@ -121,7 +109,7 @@ sub do_requires {
+ 					open(MANIFEST, "$MANIFEST_NAME");
+ 					chdir $cdir;
+ 				}
+-			} else  {
++			} else {
+ 				open(MANIFEST, "$file");
+ 			}
+        			my %reqcomp = ();
+@@ -146,8 +134,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ sub parsePkgString {
+@@ -157,6 +144,12 @@ sub parsePkgString {
+         $bunstr =~ s/\n//g;
+         $bunstr =~ s/[^[:print:]]//g;
+         $bunstr =~ s/("[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+)(,)([[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+")/$1 $3/g;
++	# Remove uses bundle from Export-Package
++	$bunstr =~ s/uses:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
++	# Remove optional dependencies 
++	$bunstr =~ s/,[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+;resolution:=optional//g;
++	# Remove x-friends 
++	$bunstr =~ s/;x-friends:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
+         @reqcomp = split /,/g, $bunstr;
+         foreach $reqelement (@reqcomp) {
+                 @reqelementfrmnt = split /;/g, $reqelement;
+@@ -170,7 +163,6 @@ sub parsePkgString {
+                         }
+                 }
+                 $version = parseVersion($version);
+-		$version = fixVersion($version);
+ 		# dirty fix for provides that contain " char
+ 		$name =~ s/\"//g;
+                 push @return, { NAME=>"$name", VERSION=>"$version"};
+@@ -183,21 +175,13 @@ sub parseVersion {
+         my $ver = $_[0];
+         if ($ver eq "") { return "";}
+         if ($ver =~ m/(^[\[|\(])(.+)\ (.+)([\]|\)]$)/) {
+-		# FIXME: The right rpm match of osgi version [1,2) seems to be <= 2
++		# FIXME: The right RPM match of osgi version [1,2) seem to be <= 2
+ 		# but when you look at the requires >= look more permssive/correct?
+ 		($1 eq "\[") ? return " >= $2" : return " > $2";
+         } else {
+-                return " = $ver";
++		# FIXME: Same here, equal seem to be the correct version match operator.
++                return " >= $ver";
+         }
+         return $ver;
+ }
+ 
+-sub fixVersion {
+-        my $version = $_[0];
+-	# remove version qualifier.
+-	$version =~ s/\.v.[0-9]*.*//g;
+-	# We try to match RPM version, so remove last .0
+-	$version =~ s/\.0$//g;
+-	return $version;
+-}
+-

--- a/attachment/ticket/39/osgideps.pl.patch
+++ b/attachment/ticket/39/osgideps.pl.patch
@@ -1,0 +1,144 @@
+diff --git a/scripts/osgideps.pl b/scripts/osgideps.pl
+index 7b02016..facd996 100644
+--- a/scripts/osgideps.pl
++++ b/scripts/osgideps.pl
+@@ -1,14 +1,12 @@
+ #!/usr/bin/perl
+ 
+-
+ use Cwd;
+ use Getopt::Long;
+-
++use File::Temp qw/ tempdir /;
+ 
+ $cdir = getcwd();
+-$TEMPDIR="/tmp";
+-$MANIFEST_NAME="META-INF/MANIFEST.MF";
+-
++$TEMPDIR = tempdir($template, CLEANUP => 1);
++$MANIFEST_NAME = "META-INF/MANIFEST.MF";
+ 
+ # prepare temporary directory
+ if (! (-d $TEMPDIR)) {
+@@ -18,29 +16,21 @@ if (! (-d $TEMPDIR)) {
+ 
+ # parse options
+ my ($show_provides, $show_requires);
+-
+ my $result = GetOptions("provides" => \$show_provides,
+-			"requires" => \$show_requires);
+-
++		"requires" => \$show_requires);
+ exit(1) if (not $result);
+ 
+-
+-
++# run selected sub
+ @allfiles = <STDIN>;
+-
+ if ($show_provides) {
+ 	do_provides(@allfiles);
+ }
+-
+ if ($show_requires) {
+ 	do_requires(@allfiles);
+ }
+-
+-
+ exit(0);
+ 
+ 
+-
+ sub do_provides {
+ 
+ foreach $file (@_) {
+@@ -55,7 +45,7 @@ foreach $file (@_) {
+ 	        	        chdir $TEMPDIR;
+ 			        `jar xf $file $MANIFEST_NAME`;	
+ 		               	open(MANIFEST, "$MANIFEST_NAME");
+-				chdir $cdir;
++ 				chdir $cdir;
+ 			}
+ 	        } else  {
+ 			open(MANIFEST, "$file");
+@@ -71,7 +61,6 @@ foreach $file (@_) {
+                 	}
+ 	                if (m/(^Bundle-Version: )(.*)/) {
+ 				$version = $2;
+-				$version = fixVersion($version);
+ 			}
+ 		        if (m/(^(Export-Package): )(.*)$/) {
+ 	        		my $bunlist = "$3"."\n";
+@@ -100,8 +89,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ 
+@@ -121,7 +109,7 @@ sub do_requires {
+ 					open(MANIFEST, "$MANIFEST_NAME");
+ 					chdir $cdir;
+ 				}
+-			} else  {
++			} else {
+ 				open(MANIFEST, "$file");
+ 			}
+        			my %reqcomp = ();
+@@ -146,8 +134,7 @@ $list = "";
+ for $bundle (@bundlelist) {
+ 	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+ }
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++print $list;
+ }
+ 
+ sub parsePkgString {
+@@ -157,6 +144,10 @@ sub parsePkgString {
+         $bunstr =~ s/\n//g;
+         $bunstr =~ s/[^[:print:]]//g;
+         $bunstr =~ s/("[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+)(,)([[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+")/$1 $3/g;
++	# Remove uses bundle from Export-Package OSGI property
++	$bunstr =~ s/uses:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
++	# Remove optional dependencies 
++	$bunstr =~ s/,[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+;resolution:=optional//g;
+         @reqcomp = split /,/g, $bunstr;
+         foreach $reqelement (@reqcomp) {
+                 @reqelementfrmnt = split /;/g, $reqelement;
+@@ -170,7 +161,6 @@ sub parsePkgString {
+                         }
+                 }
+                 $version = parseVersion($version);
+-		$version = fixVersion($version);
+ 		# dirty fix for provides that contain " char
+ 		$name =~ s/\"//g;
+                 push @return, { NAME=>"$name", VERSION=>"$version"};
+@@ -183,21 +173,13 @@ sub parseVersion {
+         my $ver = $_[0];
+         if ($ver eq "") { return "";}
+         if ($ver =~ m/(^[\[|\(])(.+)\ (.+)([\]|\)]$)/) {
+-		# FIXME: The right rpm match of osgi version [1,2) seems to be <= 2
++		# FIXME: The right RPM match of osgi version [1,2) seem to be <= 2
+ 		# but when you look at the requires >= look more permssive/correct?
+ 		($1 eq "\[") ? return " >= $2" : return " > $2";
+         } else {
+-                return " = $ver";
++		# FIXME: Same here, equal seem to be the correct version match operator.
++                return " >= $ver";
+         }
+         return $ver;
+ }
+ 
+-sub fixVersion {
+-        my $version = $_[0];
+-	# remove version qualifier.
+-	$version =~ s/\.v.[0-9]*.*//g;
+-	# We try to match RPM version, so remove last .0
+-	$version =~ s/\.0$//g;
+-	return $version;
+-}
+-

--- a/attachment/ticket/39/osgideps.pl.patch.20090617
+++ b/attachment/ticket/39/osgideps.pl.patch.20090617
@@ -1,0 +1,522 @@
+--- osgideps.pl.ori	2009-04-16 11:30:39.000000000 +0200
++++ osgideps.pl	2009-06-17 10:58:22.849272922 +0200
+@@ -1,203 +1,357 @@
+ #!/usr/bin/perl
+-
++#
++# osgideps.pl -- Analyze dependencies of OSGi bundles.
++#
++# Kyu Lee
++# Alphonse Van Assche <alcapcom@fedoraproject.org>
++#
++# $Id: osgideps.pl,v 1.0 2009/06/08 12:12:12 mej Exp $
++#
+ 
+ use Cwd;
+ use Getopt::Long;
+-
++use File::Temp qw/ tempdir /;
+ 
+ $cdir = getcwd();
+-$TEMPDIR="/tmp";
+-$MANIFEST_NAME="META-INF/MANIFEST.MF";
+-
++$TEMPDIR = tempdir( CLEANUP => 1 );
++$MANIFEST_NAME = "META-INF/MANIFEST.MF";
+ 
+ # prepare temporary directory
+-if (! (-d $TEMPDIR)) {
+-        if (($_ = `mkdir $TEMPDIR`) != 0) {exit 1;}
+-        elsif (! (-w $TEMPDIR) && (-x $TEMPDIR)) {exit 1;}
++if ( !( -d $TEMPDIR ) ) {
++	if ( ( $_ = `mkdir $TEMPDIR` ) != 0 ) { exit 1; }
++	elsif ( !( -w $TEMPDIR ) && ( -x $TEMPDIR ) ) { exit 1; }
+ }
+ 
+ # parse options
+-my ($show_provides, $show_requires);
+-
+-my $result = GetOptions("provides" => \$show_provides,
+-			"requires" => \$show_requires);
+-
+-exit(1) if (not $result);
+-
+-
++my ( $show_provides, $show_requires, $show_system_bundles, $debug );
++my $result = GetOptions(
++	"provides" => \$show_provides,
++	"requires" => \$show_requires,
++	"system" => \$show_system_bundles,
++	"debug" => \$debug
++);
++exit(1) if ( not $result );
+ 
++# run selected function
+ @allfiles = <STDIN>;
+-
+ if ($show_provides) {
+-	do_provides(@allfiles);
++	getProvides(@allfiles);
+ }
+-
+ if ($show_requires) {
+-	do_requires(@allfiles);
++	getRequires(@allfiles);
++}
++if ($show_system_bundles) {
++	getSystemBundles(@allfiles);
+ }
+-
+-
+ exit(0);
+ 
++# this function print provides of OSGi aware files
++sub getProvides {
++	foreach $file (@_) {
++		chomp($file);
++		# we don't follow symlinks for provides
++		next if -f $file && -r $file && -l $file;
++		$file =~ s/[^[:print:]]//g;
++		if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
++			if ( $file =~ m/\.jar$/ ) {
++				if ( `jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
++					# extract MANIFEST.MF file from jar to temporary directory
++					chdir $TEMPDIR;
++					`jar xf $file $MANIFEST_NAME`;
++					open( MANIFEST, "$MANIFEST_NAME" );
++					chdir $cdir;
++				}
++			} else {
++				open( MANIFEST, "$file" );
++			}
++			my $bundleName = "";
++			my $version = "";
++			# parse Bundle-SymbolicName, Bundle-Version and Export-Package attributes
++			while (<MANIFEST>) {
++				# get rid of non-print chars (some manifest files contain weird chars)
++				s/[^[:print]]//g;
++				if ( m/(^(Bundle-SymbolicName): )(.*)$/ ) {
++					$bundleName = "$3" . "\n";
++					while (<MANIFEST>) {
++						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++							$len = length $_;
++							seek MANIFEST, $len * -1, 1;
++							last;
++						}
++						$bundleName .= "$_";
++					}
++					$bundleName =~ s/\s+//g;
++					$bundleName =~ s/;.*//g;
++				}
++				if ( m/(^Bundle-Version: )(.*)/ ) {
++					$version = $2;
++				}
++				if ( m/(^(Export-Package): )(.*)$/ ) {
++					my $bunlist = "$3" . "\n";
++					while (<MANIFEST>) {
++						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++							$len = length $_;
++							seek MANIFEST, $len * -1, 1;
++							last;
++						}
++						$bunlist .= "$_";
++					}
++					push @bundlelist, parsePkgString($bunlist, $file);
++				}
++			}
+ 
+-
+-sub do_provides {
+-
+-foreach $file (@_) {
+-
+-	next if -f $file && -r $file && !-l $file;
+-	$file =~ s/[^[:print:]]//g;
+-	if ($file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
+-		if ($file =~ m/\.jar$/) {
+-        		# if this jar contains MANIFEST.MF file
+-	        	if (`jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n") {
+-		               	# extract MANIFEST.MF file from jar to temporary directory
+-	        	        chdir $TEMPDIR;
+-			        `jar xf $file $MANIFEST_NAME`;	
+-		               	open(MANIFEST, "$MANIFEST_NAME");
+-				chdir $cdir;
+-			}
+-	        } else  {
+-			open(MANIFEST, "$file");
+-	        }
+-        	my $bundleName = "";
+-	        my $version = "";
+-        	# parse bundle name and version
+-	        while(<MANIFEST>) {
+-        		# get rid of non-print chars (some manifest files contain weird chars)
+-                	s/[^[:print]]//g;
+-	                if (m/(^Bundle-SymbolicName: )((\w|\.)+)(\;*)(.*\n)/) {
+-        	        	$bundleName = $2;
+-                	}
+-	                if (m/(^Bundle-Version: )(.*)/) {
+-				$version = $2;
+-				$version = fixVersion($version);
+-			}
+-		        if (m/(^(Export-Package): )(.*)$/) {
+-	        		my $bunlist = "$3"."\n";
+-				while(<MANIFEST>) {
+-					if (m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/) {
+-						$len = length $_;
+-						seek MANIFEST, $len*-1 , 1;
+-						last;
+-                        		}
+-					$bunlist.="$_";
+-				}
+-				push @bundlelist,  parsePkgString($bunlist);
+-			}
+-                }
+-                # skip this jar if no bundle name exists
+-                if (! $bundleName eq "") {
+-			if (! $version eq "") {
+-				print "osgi(".$bundleName.") = ".$version."\n";
+-	                } else {
+-                                print "osgi(".$bundleName.")\n";
+-                        }
+-                }
+-	}
+-}
+-$list = "";
+-for $bundle (@bundlelist) {
+-	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+-}
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++			# skip this jar if no bundle name exists
++			if ( !$bundleName eq "" ) {
++				if ( !$version eq "" ) {
++					$version = parseVersion($version);
++					push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "$version" };
++				} else {
++					push @bundlelist, { FILE => "$file", NAME => "$bundleName", VERSION => "" };
++				}
++			}
++		}
++	}
++	if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
++	$list = "";
++	for $bundle (@bundlelist) {
++		if ( !$debug ) {
++			$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		} else {
++			$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		}
++	}
++	print $list;
+ }
+ 
+-
+-sub do_requires {
+-
++# this function print requires of OSGi aware files
++sub getRequires {
+ 	foreach $file (@_) {
+-
+-		next if -f $file && -r $file;
++		next if (-f $file && -r $file);
++		# we explicitly requires symlinked jars
++		if (-l $file) {
++			$file = readlink $file;
++			if ( !$file eq "" ) {							
++				print "$file" . "\n";
++			}
++			next;
++		} 
+ 		$file =~ s/[^[:print:]]//g;
+-		if ($file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
+-			if ($file =~ m/\.jar$/) {
+-				# if this jar contains MANIFEST.MF file
+-		        	if (`jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n") {
++		if ( $file =~ m/$MANIFEST_NAME$/ || $file =~ m/\.jar$/ ) {
++			if ( $file =~ m/\.jar$/ ) {
++				if ( `jar tf $file | grep -e \^$MANIFEST_NAME` eq "$MANIFEST_NAME\n" ) {
+ 					# extract MANIFEST.MF file from jar to temporary directory
+-			                chdir $TEMPDIR;
+-					`jar xf $file $MANIFEST_NAME`;	
+-					open(MANIFEST, "$MANIFEST_NAME");
++					chdir $TEMPDIR;
++					`jar xf $file $MANIFEST_NAME`;
++					open( MANIFEST, "$MANIFEST_NAME" );
+ 					chdir $cdir;
+ 				}
+-			} else  {
+-				open(MANIFEST, "$file");
++			} else {
++				open( MANIFEST, "$file" );
++			}
++			while (<MANIFEST>) {
++				if ( m/(^(Require-Bundle|Import-Package): )(.*)$/ ) {
++					my $bunlist = "$3" . "\n";
++					while (<MANIFEST>) {
++						if (m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++							$len = length $_;
++							seek MANIFEST, $len * -1, 1;
++							last;
++						}
++						$bunlist .= "$_";
++					}
++					push @bundlelist, parsePkgString($bunlist, $file);
++				}
++				# we also explicitly require symlinked jars define by 
++				# Bundle-ClassPath attribut
++				if ( m/(^(Bundle-ClassPath): )(.*)$/ ) {
++					$bunclp = "$3" . "\n";
++					while (<MANIFEST>) {
++						if ( m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/ ) {
++							$len = length $_;
++							seek MANIFEST, $len * -1, 1;
++							last;
++						}
++						$bunclp .= "$_";
++					}
++					$bunclp =~ s/\ //g;
++					$bunclp =~ s/\n//g;
++					$bunclp =~ s/[^[:print:]]//g;
++					$dir = `dirname $file`;
++					$dir =~ s/\n//g;
++					@jars = split /,/, $bunclp;
++					for $jarfile (@jars) {
++						$jarfile = "$dir\/\.\.\/$jarfile";
++						$jarfile = readlink $jarfile;
++						if ( !$jarfile eq "" ) {							
++							print "$jarfile" . "\n";
++						}
++					}
++				}
+ 			}
+-       			my %reqcomp = ();
+-	                while(<MANIFEST>) {
+-        	                if (m/(^(Require-Bundle|Import-Package): )(.*)$/) {
+-				my $bunlist = "$3"."\n";
+-                                while(<MANIFEST>) {
+-                                        if (m/^[[:upper:]][[:alpha:]]+-[[:upper:]][[:alpha:]]+: .*/) {
+-                                                $len = length $_;
+-                                                seek MANIFEST, $len*-1 , 1;
+-                                                last;
+-                                        }
+-					$bunlist.="$_";
+-                                }
+-				push @bundlelist,  parsePkgString($bunlist);
+-                        }
+-                }
++		}
+ 	}
++	if ( !$debug ) { @bundlelist = prepareOSGiBundlesList(@bundlelist); }
++	$list = "";
++	for $bundle (@bundlelist) {
++		# replace '=' by '>=' because qualifiers are set on provides 
++		# but not on requires.
++		$bundle->{VERSION} =~ s/\ =/\ >=/g;
++		if ( !$debug ) {
++			$list .= "osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		} else {
++			$list .= $bundle->{FILE} . " osgi(" . $bundle->{NAME} . ")" . $bundle->{VERSION} . "\n";
++		}
++	}
++	print $list;
+ }
+ 
+-$list = "";
+-for $bundle (@bundlelist) {
+-	$list .= "osgi(".$bundle->{NAME}.")".$bundle->{VERSION}."\n";
+-}
+-# For now we dont take Require-Bundle AND Import-Package in account
+-#print $list;
++# this function print system bundles of OSGi profile files.
++sub getSystemBundles {
++	foreach $file (@_) {
++		if ( -r $file && -r $file ) {
++			print "'$file' file not found or cannot be read!";
++			next;
++		} else {
++			open( PROFILE, "$file" );
++			while (<PROFILE>) {
++				if ( $file =~ m/\.profile$/ ) {
++					if (m/(^(org\.osgi\.framework\.system\.packages)[=|\ ]+)(.*)$/) {
++						$syspkgs = "$3" . "\n";
++						while (<PROFILE>) {
++							if (m/^[a-z]/) {
++								$len = length $_;
++								seek MANIFEST, $len * -1, 1;
++								last;
++							}
++							$syspkgs .= "$_";
++						}
++						$syspkgs =~ s/\s+//g;
++						$syspkgs =~ s/\\//g;
++						@bundles = split /,/, $syspkgs;
++						foreach $bundle (@bundles) {
++							print "osgi(" . $bundle . ")\n";
++						}
++					}
++				}
++			}
++		}
++	}
+ }
+ 
+ sub parsePkgString {
+-        my $bunstr = $_[0];
+-        my @return;
++	my $bunstr = $_[0];
++	my $file = $_[1];
++	my @return;
+ 	$bunstr =~ s/ //g;
+-        $bunstr =~ s/\n//g;
+-        $bunstr =~ s/[^[:print:]]//g;
+-        $bunstr =~ s/("[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+)(,)([[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+")/$1 $3/g;
+-        @reqcomp = split /,/g, $bunstr;
+-        foreach $reqelement (@reqcomp) {
+-                @reqelementfrmnt = split /;/g, $reqelement;
+-                $name="";
+-                $version="";
+-                $name = $reqelementfrmnt[0];
+-                for $i (1 .. $#reqelementfrmnt) {
+-                        if ($reqelementfrmnt[$i] =~ m/(^(bundle-|)version=")(.*)(")/){
+-                                $version = $3;
+-                                last;
+-                        }
+-                }
+-                $version = parseVersion($version);
+-		$version = fixVersion($version);
+-		# dirty fix for provides that contain " char
++	$bunstr =~ s/\n//g;
++	$bunstr =~ s/[^[:print:]]//g;
++	$bunstr =~ s/("[[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+)(,)([[:alnum:]|\-|\_|\.|\(|\)|\[|\]]+")/$1 $3/g;
++	# remove uses bundle from Export-Package attribute
++	$bunstr =~ s/uses:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
++	# remove optional dependencies
++	$bunstr =~ s/,.*;resolution:=optional//g;
++	# remove x-friends
++	$bunstr =~ s/;x-friends:="[[:alnum:]|\-|\_|\.|\(|\)|\[|\]|,]+"//g;
++	# remove signatures 
++	$bunstr =~ s/Name:.*SHA1-Digest:.*//g;
++	@reqcomp = split /,/, $bunstr;
++	foreach $reqelement (@reqcomp) {
++		@reqelementfrmnt = split /;/, $reqelement;
++		$name = "";
++		$version = "";
++		$name = $reqelementfrmnt[0];
+ 		$name =~ s/\"//g;
+-                push @return, { NAME=>"$name", VERSION=>"$version"};
+-        }
+-
+-        return @return;
++		# ignore 'system.bundle'.
++		# see http://help.eclipse.org/stable/index.jsp?topic=/org.eclipse.platform.doc.isv/porting/3.3/incompatibilities.html
++		next if ( $name =~ m/^system\.bundle$/ );
++		for $i ( 1 .. $#reqelementfrmnt ) {
++			if ( $reqelementfrmnt[$i] =~ m/(^(bundle-|)version=")(.*)(")/ ) {
++				$version = $3;
++				last;
++			}
++		}
++		$version = parseVersion($version);
++		push @return, { FILE => "$file", NAME => "$name", VERSION => "$version" };
++	}
++	return @return;
+ }
+ 
+ sub parseVersion {
+-        my $ver = $_[0];
+-        if ($ver eq "") { return "";}
+-        if ($ver =~ m/(^[\[|\(])(.+)\ (.+)([\]|\)]$)/) {
+-		# FIXME: The right rpm match of osgi version [1,2) seems to be <= 2
+-		# but when you look at the requires >= look more permssive/correct?
+-		($1 eq "\[") ? return " >= $2" : return " > $2";
+-        } else {
+-                return " = $ver";
+-        }
+-        return $ver;
+-}
+-
+-sub fixVersion {
+-        my $version = $_[0];
+-	# remove version qualifier.
+-	$version =~ s/\.v.[0-9]*.*//g;
+-	# We try to match RPM version, so remove last .0
+-	$version =~ s/\.0$//g;
+-	return $version;
++	my $ver = $_[0];
++	if ( $ver eq "" ) { return ""; }
++	if ( $ver =~ m/(^[\[|\(])(.+)\ (.+)([\]|\)]$)/ ) {
++		if ( $1 eq "\[" ) {
++			$ver = " >= $2";
++		} else {
++			$ver = " > $2";
++		}
++	} else {
++		$ver = " = $ver";
++	}
++	# we always return a full OSGi version to be able to match 1.0
++	# and 1.0.0 as equal in RPM.
++	( $major, $minor, $micro, $qualifier ) = split( '\.', $ver );
++	if ( !defined($minor) || !$minor ) {
++		$minor = 0;
++	}
++	if ( !defined($micro) || !$micro ) {
++		$micro = 0;
++	}
++	if ( !defined($qualifier) || !$qualifier ) {
++		$qualifier = "";
++	} else {
++		$qualifier = "." . $qualifier;
++	}
++	$ver = $major . "." . $minor . "." . $micro . $qualifier;
++	return $ver;
+ }
+ 
++# this function put the max version on each bundles to be able to remove
++# duplicate deps with 'sort -u' command.
++sub prepareOSGiBundlesList {
++	foreach $bundle (@_) {
++		foreach $cmp (@_) {
++			if ( $bundle->{NAME} eq $cmp->{NAME} ) {
++				$result = compareVersion( $bundle->{VERSION}, $cmp->{VERSION} );
++				if ( $result < 0 ) {
++					$bundle->{VERSION} = $cmp->{VERSION};
++				}
++			}
++		}
++	}
++	return @_; 
++}
++
++# this function returns a negative integer, zero, or a positive integer if 
++# $ver1 is less than, equal to, or greater than $ver2.
++#
++# REMEMBER: we mimic org.osgi.framework.Version#compareTo method but
++# *at this time* we don't take care of the qualifier part of the version.
++sub compareVersion {
++	my $ver1 = $_[0];
++	my $ver2 = $_[1];
++	
++	$ver1 = "0.0.0" if ( $ver1 eq "" );
++	$ver2 = "0.0.0" if ( $ver2 eq "" );
++
++	$ver1 =~ m/([0-9]+)(\.)([0-9]+)(\.)([0-9]+)/;
++	$major1 = $1;
++	$minor1 = $3;
++	$micro1 = $5;
++
++	$ver2 =~ m/([0-9]+)(\.)([0-9]+)(\.)([0-9]+)/;
++	$major2 = $1;
++	$minor2 = $3;
++	$micro2 = $5;
++
++	$result = $major1 - $major2;
++	return $result if ( $result != 0 );
++	
++	$result = $minor1 - $minor2;
++	return $result if ( $result != 0 );
++	
++	$result = $micro1 - $micro2;
++	return $result if ( $result != 0 );
++	
++	return $result;
++}

--- a/attachment/ticket/39/rpm-osgideps-check
+++ b/attachment/ticket/39/rpm-osgideps-check
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+
+import rpm
+import os
+import sys
+import getopt
+import commands
+from rpmUtils.miscutils import stringToVersion
+
+DEFAULT_CMP="find $(pwd) -type f"
+PROV="/tmp/osgi-prov.txt"
+REQ="/tmp/osgi-req.txt"
+
+# this function was take out of rpmdev-vercmp
+def vercmp((e1, v1, r1), (e2, v2, r2)):
+   rc = rpm.labelCompare((e1, v1, r1), (e2, v2, r2))
+   return rc
+
+def usage():
+	print "This script check if osgideps.pl RPM deps generator can be activate on a given list of OSGI bundles.\n"
+	print "Usage: osgideps-check [option]"
+	print "	-h --help		show this help"
+	print "	-c --command	command that print a list of file to stdin (e.g find /usr/shar/java -type f)"
+	print "  -d --debug		run from '/tmp/osgi-prov.txt' and '/tmp/osgi-prov.txt' pre-builded file"
+
+# parse params          
+cmd = DEFAULT_CMP
+debug = False                 
+try:                                
+	opts, args = getopt.getopt(sys.argv[1:], "hcd", ["help", "command=", "debug"]) 
+except getopt.GetoptError:           
+	usage()                          
+	sys.exit(2)
+
+for opt, arg in opts:
+	if opt in ("-h", "--help"):
+		usage()                     
+		sys.exit()                  
+	elif opt in ("-c", "--command"):
+		cmd = arg  
+	elif opt in ("-d", "--debug"):
+		debug = True
+		
+if debug == False:
+	cmd_req = "%s | /usr/lib/rpm/osgideps.pl -r | sort -u > %s" % (cmd, REQ)
+	cmd_prov = "%s | /usr/lib/rpm/osgideps.pl -p | sort -u > %s" % (cmd, PROV)
+	print "Running '%s'..." % cmd_req
+	os.system(cmd_req)	
+	print "Running '%s'..." % cmd_prov
+	os.system(cmd_prov)
+
+reqs = open(REQ, 'r')
+for req in reqs:
+	isProv = False
+	reqIsNewerThanProv = False
+	providedBundles = ""
+	provs = open(PROV, 'r')
+	for prov in provs:
+		reqBundle = str(req).strip().split(" ")[0]
+		provBundle = str(prov).strip().split(" ")[0]
+		reqVersion = ""; provVersion = ""		
+		if  reqBundle == provBundle:
+			# TODO: This assume that provide without version match all requires and vis versa.
+			# (I think that rpm work like that be I'm currently not 100% sure of that)
+			try:
+				reqVersion = str(req).strip().split(" ")[2].strip()
+				provVersion = str(prov).strip().split(" ")[2].strip()
+				reqCmp = str(req).strip().split(" ")[1].strip()
+				provCmp = str(prov).strip().split(" ")[1].strip()
+				(e1, v1, r1) = stringToVersion(provVersion)
+				(e2, v2, r2) = stringToVersion(reqVersion)
+				rc = vercmp((e1, v1, r1), (e2, v2, r2))
+				# We stricly check version matching here.
+				if (reqCmp == '=' and rc == 0) or (reqCmp == '>=' and rc >= 0):
+					isProv = True
+					exit
+				else:
+					isProv = False
+					providedBundles = str(prov).strip() + " "
+					reqIsNewerThanProv = True 
+			except:
+				isProv = True
+				if (reqVersion.strip() != "" and provVersion.strip() != ""):
+					print "ERROR: This script suck for '%s' bundle req:%s - prov:%s" % (reqBundle, reqVersion, provVersion)
+	provs.close()
+	if isProv == False:
+		if reqIsNewerThanProv == True:
+			print "ERROR: req:'%s' '%s' prov:'%s'" % (req.strip(), reqCmp, providedBundles) 
+		else:	
+			# We check if the osgi bundle is provided by osgi-system-package meta rpm package
+			(status, output) = commands.getstatusoutput("rpm -q --whatprovides '%s' | grep osgi-system-package" % reqBundle) 
+			if status != 0:
+				print "ERROR: bundle '%s' not provided" % str(req).strip()
+reqs.close()
+
+
+           
+

--- a/attachment/ticket/52/0003-Add-disable-dependency-tracking-to-configure-opti.patch
+++ b/attachment/ticket/52/0003-Add-disable-dependency-tracking-to-configure-opti.patch
@@ -1,0 +1,27 @@
+From c9a3fdd25bf17e868c186aa6d08a9f8c80aeae4b Mon Sep 17 00:00:00 2001
+From: =?utf-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Sun, 19 Apr 2009 23:51:19 +0300
+Subject: [PATCH] Add --disable-dependency-tracking to %configure options.
+
+autotools dependency tracking isn't generally useful in rpm builds;
+disabling it results in cleaner build logs and possibly slight build
+speedups.
+---
+ macros.in |    1 +
+ 1 files changed, 1 insertions(+), 0 deletions(-)
+
+diff --git a/macros.in b/macros.in
+index c187f62..4738857 100644
+--- a/macros.in
++++ b/macros.in
+@@ -1018,6 +1018,7 @@ print (t)\
+   %{_configure} --host=%{_host} --build=%{_build} \\\
+ 	--target=%{_target_platform} \\\
+ 	--program-prefix=%{?_program_prefix} \\\
++	--disable-dependency-tracking \\\
+ 	--prefix=%{_prefix} \\\
+ 	--exec-prefix=%{_exec_prefix} \\\
+ 	--bindir=%{_bindir} \\\
+-- 
+1.6.0.6
+

--- a/attachment/ticket/63/13-rpm2cpio-help.diff
+++ b/attachment/ticket/63/13-rpm2cpio-help.diff
@@ -1,0 +1,28 @@
+Add in a -h (help) command for rpm2cpio
+
+From:  <>
+
+
+---
+
+ rpm2cpio.c |    8 +++++++-
+ 1 files changed, 7 insertions(+), 1 deletions(-)
+
+--- a/rpm2cpio.c
++++ b/rpm2cpio.c
+@@ -23,8 +23,14 @@
+     setprogname(argv[0]);	/* Retrofit glibc __progname */
+     if (argc == 1)
+ 	fdi = fdDup(STDIN_FILENO);
+-    else
++    else {
++        /* -h switch added for Debian because a user asked for it */
++        if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
++            fprintf(stderr, "Usage: rpm2cpio file.rpm\n");
++            exit(1);
++        }
+ 	fdi = Fopen(argv[1], "r.ufdio");
++    }
+ 
+     if (Ferror(fdi)) {
+ 	fprintf(stderr, "%s: %s: %s\n", argv[0],

--- a/attachment/ticket/65/60_fix-out-build.patch
+++ b/attachment/ticket/65/60_fix-out-build.patch
@@ -1,0 +1,14 @@
+Fix out of sources build.
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -57,8 +57,8 @@
+ librpm_la_LIBADD += @WITH_DB_LIB@
+ endif
+ 
+-tagtbl.c: Makefile.am $(top_srcdir)/lib/rpmtag.h gentagtbl.sh
+-	@AWK=${AWK} ${SHELL} gentagtbl.sh $(top_srcdir)/lib/rpmtag.h > $@
++tagtbl.c: Makefile.am $(top_srcdir)/lib/rpmtag.h $(top_srcdir)/lib/gentagtbl.sh
++	@AWK=${AWK} ${SHELL} $(top_srcdir)/lib/gentagtbl.sh $(top_srcdir)/lib/rpmtag.h > $@
+ BUILT_SOURCES = tagtbl.c
+ 
+ if WITH_INTERNAL_DB

--- a/attachment/ticket/69/0004-Add-d-option-to-patch.patch
+++ b/attachment/ticket/69/0004-Add-d-option-to-patch.patch
@@ -1,0 +1,98 @@
+From 412b7ddf2391d248a9232d5007c3f73c8d93e2df Mon Sep 17 00:00:00 2001
+From: =?utf-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Tue, 16 Jun 2009 22:25:02 +0300
+Subject: [PATCH] Add -d option to %patch.
+
+---
+ build/parsePrep.c |   20 ++++++++++++++------
+ 1 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/build/parsePrep.c b/build/parsePrep.c
+index e676908..ba2a919 100644
+--- a/build/parsePrep.c
++++ b/build/parsePrep.c
+@@ -40,18 +40,20 @@ static rpmRC checkOwners(const char * urlfn)
+  * @param strip		patch level (i.e. patch -p argument)
+  * @param db		saved file suffix (i.e. patch --suffix argument)
+  * @param reverse	include -R?
+- * @param fuzz		fuzz factor, fuzz<0 means no fuzz set
+  * @param removeEmpties	include -E?
++ * @param fuzz		fuzz factor, fuzz<0 means no fuzz set
++ * @param dir		dir to change to (i.e. patch -d argument)
+  * @return		expanded %patch macro (NULL on error)
+  */
+ 
+ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
+-		     int reverse, int removeEmpties, int fuzz)
++		     int reverse, int removeEmpties, int fuzz, const char *dir)
+ {
+     char *fn;
+     char *buf = NULL;
+     char *arg_backup = NULL;
+     char *arg_fuzz = NULL;
++    char *arg_dir = NULL;
+     char *args = NULL;
+     char *arg_patch_flags = rpmExpand("%{?_default_patch_flags}", NULL);
+     struct Source *sp;
+@@ -87,11 +89,15 @@ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
+ 		  "--suffix %s", db);
+     } else arg_backup = xstrdup("");
+ 
++    if (dir) {
++	rasprintf(&arg_dir, " -d %s", dir);
++    } else arg_dir = xstrdup("");
++
+     if (fuzz >= 0) {
+ 	rasprintf(&arg_fuzz, " --fuzz=%d", fuzz);
+     } else arg_fuzz = xstrdup("");
+ 
+-    rasprintf(&args, "%s -p%d %s%s%s%s", arg_patch_flags, strip, arg_backup, arg_fuzz, 
++    rasprintf(&args, "%s -p%d %s%s%s%s%s", arg_patch_flags, strip, arg_backup, arg_fuzz, arg_dir,
+ 		reverse ? " -R" : "", 
+ 		removeEmpties ? " -E" : "");
+ 
+@@ -99,6 +105,7 @@ static char *doPatch(rpmSpec spec, uint32_t c, int strip, const char *db,
+ 
+     free(arg_patch_flags);
+     free(arg_fuzz);
++    free(arg_dir);
+     free(arg_backup);
+     free(args);
+ 
+@@ -399,7 +406,7 @@ static int doSetupMacro(rpmSpec spec, const char *line)
+  */
+ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
+ {
+-    char *opt_b, *opt_P;
++    char *opt_b, *opt_P, *opt_d;
+     char *buf = NULL;
+     int opt_p, opt_R, opt_E, opt_F;
+     int argc, c;
+@@ -415,13 +422,14 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
+ 	{ NULL, 'b', POPT_ARG_STRING, &opt_b, 'b', NULL, NULL },
+ 	{ NULL, 'z', POPT_ARG_STRING, &opt_b, 'z', NULL, NULL },
+ 	{ NULL, 'F', POPT_ARG_INT, &opt_F, 'F', NULL, NULL },
++	{ NULL, 'd', POPT_ARG_STRING, &opt_d, 'd', NULL, NULL },
+ 	{ NULL, 0, 0, NULL, 0, NULL, NULL }
+     };
+     poptContext optCon = NULL;
+ 
+     opt_p = opt_R = opt_E = 0;
+     opt_F = rpmExpandNumeric("%{_default_patch_fuzz}");		/* get default fuzz factor for %patch */
+-    opt_b = NULL;
++    opt_b = opt_d = NULL;
+ 
+     /* Convert %patchN to %patch -PN to simplify further processing */
+     if (! strchr(" \t\n", line[6])) {
+@@ -473,7 +481,7 @@ static rpmRC doPatchMacro(rpmSpec spec, const char *line)
+ 		     *patch, line);
+ 	    goto exit;
+ 	}
+-	s = doPatch(spec, pnum, opt_p, opt_b, opt_R, opt_E, opt_F);
++	s = doPatch(spec, pnum, opt_p, opt_b, opt_R, opt_E, opt_F, opt_d);
+ 	if (s == NULL) {
+ 	    goto exit;
+ 	}
+-- 
+1.6.0.6
+

--- a/attachment/ticket/70/foo.spec
+++ b/attachment/ticket/70/foo.spec
@@ -1,0 +1,37 @@
+Name:           foo
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Dummy test package
+
+Group:          Development/Debug
+License:        Public Domain
+URL:            http://fedoraproject.org/
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+
+
+%prep
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -dm 755 $RPM_BUILD_ROOT/tmp
+touch $RPM_BUILD_ROOT/tmp/{foo,bar,quux}
+echo /tmp/foo > files1
+echo /tmp/bar > files2
+echo /tmp/quux > files3
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files -f files1 -f files2 -f files3
+%defattr(-,root,root,-)
+
+
+%changelog

--- a/attachment/ticket/84/0006-Add-.xz-and-.lzma-recompress-support-to-brp-compre.patch
+++ b/attachment/ticket/84/0006-Add-.xz-and-.lzma-recompress-support-to-brp-compre.patch
@@ -1,0 +1,41 @@
+From 33c67ad75fad304d65103e033a3d59b1c8178c85 Mon Sep 17 00:00:00 2001
+From: =?utf-8?q?Ville=20Skytt=C3=A4?= <ville.skytta@iki.fi>
+Date: Tue, 4 Aug 2009 00:34:31 +0300
+Subject: [PATCH] Add *.xz and *.lzma recompress support to brp-compress.
+
+---
+ scripts/brp-compress |   10 +++++-----
+ 1 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/scripts/brp-compress b/scripts/brp-compress
+index 28051d9..2c28237 100755
+--- a/scripts/brp-compress
++++ b/scripts/brp-compress
+@@ -23,9 +23,9 @@ do
+ 	[ "`basename $f`" = "dir" ] && continue
+ 
+ 	case "$f" in
+-	 *.Z) gunzip $f; b=`echo $f | sed -e 's/\.Z$//'`;;
+-	 *.gz) gunzip $f; b=`echo $f | sed -e 's/\.gz$//'`;;
+-	 *.bz2) bunzip2 $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
++	 *.gz|*.Z)    gunzip  $f; b=`echo $f | sed -e 's/\.\(gz\|Z\)$//'`;;
++	 *.bz2)       bunzip2 $f; b=`echo $f | sed -e 's/\.bz2$//'`;;
++	 *.xz|*.lzma) unxz    $f; b=`echo $f | sed -e 's/\.\(xz\|lzma\)$//'`;;
+ 	 *) b=$f;;
+ 	esac
+ 
+@@ -48,9 +48,9 @@ do
+ 
+     for f in `find $d -type l`
+     do
+-	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
++	l=`ls -l $f | sed -e 's/.* -> //' -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\)$//'`
+ 	rm -f $f
+-	b=`echo $f | sed -e 's/\.gz$//' -e 's/\.bz2$//' -e 's/\.Z$//'`
++	b=`echo $f | sed -e 's/\.\(gz\|Z\|bz2\|xz\|lzma\)$//'`
+ 	ln -sf $l$COMPRESS_EXT $b$COMPRESS_EXT
+     done
+ done
+-- 
+1.6.0.6
+

--- a/attachment/ticket/89/0001-Consider-packages-that-would-build-with-specfile.patch
+++ b/attachment/ticket/89/0001-Consider-packages-that-would-build-with-specfile.patch
@@ -1,0 +1,54 @@
+From 528eb975d94e2d2e18bc868858293aeca7ea26c0 Mon Sep 17 00:00:00 2001
+From: Lubomir Rintel <lkundrak@v3.sk>
+Date: Wed, 19 Aug 2009 18:32:51 +0200
+Subject: [PATCH] Consider packages that would build with --specfile
+
+Currently --specfile takes all package structures into account, even
+those which would not result in binary packages since they lack %files
+section. This typically causes trouble with packages that only build
+into subpackages, since the user has no way if finding out which
+packages would actually build.
+
+To retain compatibility in that case this adds the source package to
+the list, using "src" as an arch, which makes it distinguishable from
+the binary packages.
+---
+ build/spec.c |   15 ++++++++++++---
+ 1 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/build/spec.c b/build/spec.c
+index 76b22a2..8c0b6da 100644
+--- a/build/spec.c
++++ b/build/spec.c
+@@ -552,7 +552,6 @@ int rpmspecQuery(rpmts ts, QVA_t qva, const char * arg)
+     int anyarch = 1;
+     int force = 1;
+     int res = 1;
+-    int xx;
+ 
+     if (qva->qva_showPackage == NULL)
+ 	goto exit;
+@@ -568,8 +567,18 @@ int rpmspecQuery(rpmts ts, QVA_t qva, const char * arg)
+     }
+ 
+     res = 0;
+-    for (pkg = spec->packages; pkg != NULL; pkg = pkg->next)
+-	xx = qva->qva_showPackage(qva, ts, pkg->header);
++
++    /* Source package */
++    initSourceHeader(spec);
++    headerPutString (spec->sourceHeader, RPMTAG_ARCH, "src");
++    qva->qva_showPackage(qva, ts, spec->sourceHeader);
++
++    /* Binary subpackages */
++    for (pkg = spec->packages; pkg != NULL; pkg = pkg->next) {
++        if (pkg->fileList == NULL)
++            continue;
++	qva->qva_showPackage(qva, ts, pkg->header);
++    }
+ 
+ exit:
+     spec = freeSpec(spec);
+-- 
+1.6.2.5
+

--- a/attachment/ticket/91/fix-luaext.patch
+++ b/attachment/ticket/91/fix-luaext.patch
@@ -1,0 +1,15 @@
+Description: Fix include path
+ These files are in source tree and not build tree.
+Author: Michal Čihař <nijel@debian.org>
+Forwarded: http://rpm.org/ticket/91
+--- a/rpmio/Makefile.am
++++ b/rpmio/Makefile.am
+@@ -32,7 +32,7 @@
+ 	-lpthread
+ 
+ if WITH_LUAEXT
+-AM_CPPFLAGS += -I$(top_builddir)/luaext/
++AM_CPPFLAGS += -I$(top_srcdir)/luaext/
+ librpmio_la_LIBADD += $(top_builddir)/luaext/libluaext.la
+ endif
+ 

--- a/ticket/101.md
+++ b/ticket/101.md
@@ -1,0 +1,51 @@
+---
+lang: en
+title: '\#101 (\[PATCH\] new osgideps.pl) - rpm - Trac'
+---
+
+Ticket \#101 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+\[PATCH\] new osgideps.pl
+-------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   alcapcom   Assigned to:   pmatilai
+  Priority:      trivial    Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+This patch fix some minor bug, remove unused code and increase
+drastically the perf by threading execution of tasks and using zip
+command instead of jar to get meta-data (It\'s at less 10 time faster
+than the current code)
+
+Alphonse
+
+Attachments
+-----------
+
+[osgideps.pl\_2009-08-25.patch](/attachment/ticket/101/osgideps.pl_2009-08-25.patch "View attachment")
+(11.9 kB) - added by *alcapcom* on 09/25/09 11:45:30.
+
+Change History
+--------------
+
+### 09/25/09 11:45:30 changed by alcapcom
+
+-   **attachment** *osgideps.pl\_2009-08-25.patch* added.
+
+### 09/29/09 06:08:25 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied in HEAD, thanks for the patch.

--- a/ticket/103.md
+++ b/ticket/103.md
@@ -1,0 +1,63 @@
+---
+lang: en
+title: '\#103 (Improve duplicate %trigger\* handling in specfiles) - rpm
+  - Trac'
+---
+
+Ticket \#103 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Improve duplicate %trigger\* handling in specfiles
+--------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+When a specfile contains more than one %post or one of the other
+\"usual\" scriptlets, rpmbuild refuses to build it and outputs an error
+message. However, this doesn\'t happen with duplicate
+%triggerin/%triggerun/%triggerpostun. The package builds fine but it
+seems that later duplicate definitions are simply silently discarded.
+
+I think either the duplicates should error out builds like with
+duplicate %post and friends, or alternatively all of them should be kept
+and executed when appropriate.
+
+For example:
+
+    %triggerin -- foo
+    echo footrigger1
+
+    %triggerin -- foo
+    echo footrigger2
+
+If not failing the build, I think this should result in both triggers
+being run when the trigger for foo fires. As of rpm 4.7.1 the latter
+trigger seems to be discarded.
+
+Change History
+--------------
+
+### 10/18/09 21:01:31 changed by pmatilai {#comment:1}
+
+Indeed, rpm 4.6.0 - 4.7.1 incorrectly discards triggers with identical
+conditions. Fixed already in HEAD, just pending maintenance updates to
+both 4.6.x and 4.7.x.
+
+### 11/26/09 07:58:32 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed in the just-released rpm 4.7.2 too now.

--- a/ticket/104.md
+++ b/ticket/104.md
@@ -1,0 +1,38 @@
+---
+lang: en
+title: '\#104 (French man page uses DOS end of lines) - rpm - Trac'
+---
+
+Ticket \#104 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+French man page uses DOS end of lines
+-------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+French man (doc/fr/rpm.8) page uses DOS end of lines, what causes
+problems to some groff parsers, can you please fix it?
+
+Change History
+--------------
+
+### 11/20/09 09:50:58 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed now in HEAD, thanks for pointing this out (must be an ages old
+issue :)

--- a/ticket/107.md
+++ b/ticket/107.md
@@ -1,0 +1,49 @@
+---
+lang: en
+title: '\#107 (Fails to build with binutils-gold) - rpm - Trac'
+---
+
+Ticket \#107 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Fails to build with binutils-gold
+---------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+binutils-gold make default \--no-add-needed option, what means that you
+need to explicitely list all libraries whose symbols binary uses.
+Currently there are two broken binaries in rpm sources. Attached patch
+fixes this.
+
+Attachments
+-----------
+
+[fix-linkage.patch](/attachment/ticket/107/fix-linkage.patch "View attachment")
+(0.7 kB) - added by *nijel* on 11/16/09 13:07:38.
+
+Change History
+--------------
+
+### 11/16/09 13:07:38 changed by nijel
+
+-   **attachment** *fix-linkage.patch* added.
+
+### 11/20/09 09:15:47 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied, thanks for the patch!

--- a/ticket/115.md
+++ b/ticket/115.md
@@ -1,0 +1,110 @@
+---
+lang: en
+title: '\#115 (create a macro for parallel make) - rpm - Trac'
+---
+
+Ticket \#115 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 1 year ago
+
+create a macro for parallel make
+--------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   stick   Assigned to:   RpmTickets
+  Priority:      minor   Milestone:     rpm-4.12.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Distributions uses these macros for parallel make: - Fedora make
+%{?\_smp\_mflags} - openSUSE: make %{?jobs:-j%jobs}
+
+We could unify notation (%{?\_smp\_mflags} works on openSUSE too) and
+add a definition to RPM upstream (maybe %make for parallel make and
+%make\_single for single?)
+
+Change History
+--------------
+
+### 12/04/09 17:54:31 changed by stick {#comment:1}
+
+-   **priority** changed from *major* to *minor*.
+
+### 12/22/09 00:18:33 changed by jengelh {#comment:2}
+
+We should be using at least `%_smp_mflags`; the hardcoded use of
+`%{?jobs:-j%jobs}` in specfiles \"forces\" the use of `-jXX`, which is
+in conflict when one wants to use `-lXX` instead, for example.
+
+("Parallel building, preferably, but I get to choose how things are
+scheduled.")
+
+`%make` and `%make_single` seems ok.
+
+### 01/22/14 10:34:04 changed by pmatilai {#comment:3}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Duh, been intending to do something about this about umphteen times but
+always gotten sidetracked or had second thoughts how to go about it.
+Anyway, I just pushed two changes that I think solve this and some other
+related issues quite nicely:
+
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=356fd73a7b24fd5fdcc093639c12dfd60f35d681](https://web.archive.org/web/20150919184356/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=356fd73a7b24fd5fdcc093639c12dfd60f35d681)
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=89df36524bace71decee4ab4f979d4ffb449c9a7](https://web.archive.org/web/20150919184356/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=89df36524bace71decee4ab4f979d4ffb449c9a7)
+
+Where you previously invoked \"make\" with assorted parallel-build
+magic, you now just use \"%make\_build\" which takes care of the
+parallel switches. The other change is to allow specifying the maximum
+numer of CPU\'s to use, which can be set on system, user or spec-level
+if desireable. This allows it to be used for overall resource control in
+addition to handling the special case of buggy makefiles (whether a
+truly serialized build is required or parallel builds beyond some value
+of N are buggy), and is nicely greppable too. So a spec might look
+something like this:
+
+    # foo-1.2 has buggy makefiles preventing parallel build
+    %global _smp_ncups_max 1
+
+    [...]
+
+    %build
+    %make_build
+
+    %install
+    %make_install
+
+In addition to the parallel build issues, the \"make\" command to use
+can be overridden with %make macro throughout the spec (previously
+%make\_install honored %make but typically specs dont use that but
+invoke \"make\" directly). Plus it can be enhanced for other things as
+its not specific to the parallel-build issues, and should help
+cross-distro unification by hiding the details from specs.
+
+### 01/22/14 11:18:05 changed by pmatilai {#comment:4}
+
+Ehm, just spotted a typo (ncups) in the above comment. The spec snippet
+should of course be
+
+    # foo-1.2 has buggy makefiles preventing parallel build
+    %global _smp_ncpus_max 1
+
+    [...]
+
+    %build
+    %make_build
+
+    %install
+    %make_install
+
+### 09/16/14 11:07:31 changed by pmatilai {#comment:5}
+
+-   **milestone** set to *rpm-4.12.0*.

--- a/ticket/116.md
+++ b/ticket/116.md
@@ -1,0 +1,140 @@
+---
+lang: en
+title: '\#116 (Add/Improve %license tag handling) - rpm - Trac'
+---
+
+Ticket \#116 (assigned defect)
+==============================
+
+Opened 6 years ago
+
+Last modified 3 years ago
+
+Add/Improve %license tag handling
+---------------------------------
+
+  -------------- ------- -------------- ---------------------
+  Reported by:   spot    Assigned to:   pmatilai (accepted)
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- ---------------------
+
+### Description {#comment:description}
+
+Currently, Fedora uses \"%doc\" to mark license texts, but this is not
+optimal for many reasons. Some licenses require that the text of the
+license always accompany the software, even in scenarios where \--nodocs
+would otherwise make sense.
+
+I propose that the %license tag be created to handle license texts.
+
+With this tag, we would now have a way to differentiate the license text
+from other documentation. This is important, because in Fedora, we are
+currently duplicating common license texts in multiple locations, simply
+to ensure compliance. It would be ideal if RPM contained logic along
+these lines:
+
+1\. Package marks license text as %license:
+
+> %doc README CHANGELOG %license COPYING
+
+2\. Upon installation, rpm looks in %\_licensedir (customizable, but as
+a default suggestion, /usr/share/licenses/) to see if any identical
+files (identical to %license) are already present on the system.
+
+3a. If an identical copy is already found in %\_licensedir, do not
+install the license text (COPYING), but create it in %\_defaultdocdir as
+a hardlink to the copy in %\_licensedir.
+
+3b. If an identical copy is not found in %licensedir, copy the license
+text to %\_defaultdocdir.
+
+\*\*\*\*\* That scenario would permit Fedora to create a
+\"common-licenses\" package that would be part of a default
+installation, and minimize the license footprint.
+
+Change History
+--------------
+
+### 07/07/10 21:48:39 changed by james {#comment:1}
+
+Note that I just did:
+
+[http://james.fedorapeople.org/yum/commands/rpmdb-common-files.py](https://web.archive.org/web/20151021001123/http://james.fedorapeople.org/yum/commands/rpmdb-common-files.py)
+
+\...with output here (the above code requires the latest HEAD atm.):
+
+[http://james.fedorapeople.org/yum/commands/rpmdb-common-files-output.txt](https://web.archive.org/web/20151021001123/http://james.fedorapeople.org/yum/commands/rpmdb-common-files-output.txt)
+
+\...doesn\'t seem like a huge win space wise, atm. \... but that might
+change with the recent Fedora change for license requirements.
+
+### 07/08/10 14:15:26 changed by pzb {#comment:2}
+
+%license already exists in RPM (has for years). However it behaves more
+like %ghost than %doc, IIRC. This means you need to give the full path
+to the file, not a relative path. While it does not solve steps 2 and 3,
+it should help with the \--nodocs problem.
+
+### 07/08/10 14:16:25 changed by spot {#comment:3}
+
+RPMTAG\_LICENSE exists, but I don\'t believe it is hooked into anything
+in the current codebase. Could be wrong.
+
+### 07/09/10 10:42:17 changed by pmatilai {#comment:4}
+
+It \"works\", but is rather broken.
+
+%license qualifier in %files list originates from the days when the
+License preamble-tag was known as Copyright, and now there\'s a
+namespace collision. So in order to use \"%license /some/path\" you need
+to escape with \"%%license /some/path\". But it doesn\'t get used for
+anything at all, never was. And it\'s cumbersome to use.
+
+The problem for making %license behave similarly to %doc is that %doc is
+implemented in such a godforsakenly hacky way it\'s not extensible at
+all. Not saying it can\'t be done, just needs somebody to get around to
+rewrite the thing in a saner way (see also ticket
+[\#53](53 "[RFE] Allow %doc(type) documentation file flagging (new)")
+which is kinda related)
+
+### 05/28/12 14:52:02 changed by pmatilai {#comment:5}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+A big pile of commits (to make the \"special docs\" mechanism a little
+less, erm, \"special\") later\...
+
+Just pushed something towards this direction to rpm.org master. No
+special install-time copying/relocation/hardlink magic at least so far,
+just making %license behave similarly to %doc but placing licenses to a
+separate directory structure and \--nodocs will not affect their
+installation as they\'re only tagged as license files, not
+documentation. So you can now do eg
+
+    %files
+    %license COPYING
+    %doc README NEWS
+
+%doc does what it always did, %license on non-absolute paths creates
+another \"special\" directory (/usr/share/licenses/%{name}-%{version} by
+default) where the licenses are copied. Simple and maybe a bit stupid,
+but then I\'m not entirely convinced these really deserve any special
+install-time magic as they\'re not that big\... and for
+space-constrained situations like live-images one can always just run
+hardlink on the entire licenses directory. OTOH hardlinking the tree
+automatically might be reasonable, I\'ll need to think about the
+\"optimization\" part a bit more.
+
+### 05/29/12 14:16:06 changed by spot {#comment:6}
+
+The benefit from hardlinking is reflected by the fact that in the
+majority of cases (e.g. GPL/LGPL), COPYING is going to be identical, and
+while we need it to be present, we don\'t need 100+ identical copies of
+it.
+
+I admit its not a huge size win, but I still think we should try to do
+it.

--- a/ticket/117.md
+++ b/ticket/117.md
@@ -1,0 +1,66 @@
+---
+lang: en
+title: '\#117 (erase doesn\''t understand epoch as an argument) - rpm -
+  Trac'
+---
+
+Ticket \#117 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 4 years ago
+
+erase doesn\'t understand epoch as an argument
+----------------------------------------------
+
+  -------------- ------- -------------- -----------
+  Reported by:   tuju    Assigned to:   akozumpl
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM 4.7.x
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------
+
+### Description {#comment:description}
+
+Previously when rpm whined something about dependencies, one could
+double click the string in terminal window and paste those nvr:s into
+next command\'s argument list.
+
+New rpm outputs also epoch (nevr) in error messages, but does not
+understand it as input.
+
+An example:
+
+    error: Failed dependencies:
+            iscsitarget-kmod >= 1:1.4.18 is needed by (installed) iscsitarget-1:1.4.18-1.fc11.x86_64
+
+and then as an input:
+
+    # rpm -e iscsitarget-1:1.4.18-1.fc11.x86_64
+    error: package iscsitarget-1:1.4.18-1.fc11.x86_64 is not installed
+
+and this succeeds when erased with plain:
+
+    # rpm -e iscsitarget
+
+It would be nice if this (much needed) epoch handling would be expanded
+into erase too at some point of development.
+
+Change History
+--------------
+
+### 11/11/11 14:03:40 changed by akozumpl {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *akozumpl*.
+-   **status** changed from *new* to *assigned*.
+
+### 11/18/11 08:54:59 changed by akozumpl {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed by
+[fa428c5bc143d2d7ac073654b602c27d80f96559](https://github.com/rpm-software-management/rpm/commit/fa428c5bc143d2d7ac073654b602c27d80f96559 "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.")
+on the master branch.

--- a/ticket/123.md
+++ b/ticket/123.md
@@ -1,0 +1,43 @@
+---
+lang: en
+title: '\#123 (Make RPMBUILD\_IS\* available in Python) - rpm - Trac'
+---
+
+Ticket \#123 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Make RPMBUILD\_IS\* available in Python
+---------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   RpmTickets
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+It\'d be nice to have RPMBUILD\_IS\* constants from rpmspec.h available
+in Python for examining source flags from rpm.spec.sources().
+
+Change History
+--------------
+
+### 03/24/10 08:29:35 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Added now:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=ee98a373cf79d3248122ae147d98ac461d59c9b7](https://web.archive.org/web/20151210102336/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=ee98a373cf79d3248122ae147d98ac461d59c9b7)
+
+I seem to recall not adding these with the intent of adding a saner way
+to access sources/patches etc to the bindings instead, but otoh this
+permits implementing some nicer spec method from python instead of C.
+I\'ll try to remember to pull this into 4.8.x branch too.

--- a/ticket/126.md
+++ b/ticket/126.md
@@ -1,0 +1,48 @@
+---
+lang: en
+title: '\#126 (\[PATCH\] Document \--conflicts in rpm(8)) - rpm - Trac'
+---
+
+Ticket \#126 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+\[PATCH\] Document \--conflicts in rpm(8)
+-----------------------------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   scop      Assigned to:   RpmTickets
+  Priority:      trivial   Milestone:     
+  Component:     rpm       Version:       RPM Development
+  Keywords:                Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+The attached patch adds \--conflicts to rpm(8) man page.
+
+Attachments
+-----------
+
+[0002-Document-conflicts-in-rpm-8.patch](/attachment/ticket/126/0002-Document-conflicts-in-rpm-8.patch "View attachment") (1.4 kB) - added by *scop* on 01/23/10 12:52:19.
+:   Document \--conflicts in rpm(8) man page
+
+Change History
+--------------
+
+### 01/23/10 12:52:19 changed by scop
+
+-   **attachment** *0002-Document-conflicts-in-rpm-8.patch* added.
+
+Document \--conflicts in rpm(8) man page
+
+### 01/25/10 10:11:50 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied, thanks.

--- a/ticket/128.md
+++ b/ticket/128.md
@@ -1,0 +1,114 @@
+---
+lang: en
+title: '\#128 (\[PATCH\] perl.{req,prov} cleanups) - rpm - Trac'
+---
+
+Ticket \#128 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+\[PATCH\] perl.{req,prov} cleanups
+----------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+The attached patch cleans up trailing whitespace, converts tabs to
+spaces, does some other whitespace cleanups, and avoids some unnecessary
+backslashes and parens in perl.prov and perl.req. This is just cleanup,
+there are no functional changes.
+
+Attachments
+-----------
+
+[0004-perl.-req-prov-whitespace-backslash-and-paren-clea.patch](/attachment/ticket/128/0004-perl.-req-prov-whitespace-backslash-and-paren-clea.patch "View attachment") (9.0 kB) - added by *scop* on 01/24/10 11:51:36.
+:   perl.{req,prov} cleanups
+
+[0002-More-here-doc-skipping-fixes-for-perl.req-128.patch](/attachment/ticket/128/0002-More-here-doc-skipping-fixes-for-perl.req-128.patch "View attachment") (0.8 kB) - added by *scop* on 03/03/10 18:51:17.
+:   More here-doc skipping fixes as discussed
+
+Change History
+--------------
+
+### 01/24/10 11:51:36 changed by scop
+
+-   **attachment**
+    *0004-perl.-req-prov-whitespace-backslash-and-paren-clea.patch*
+    added.
+
+perl.{req,prov} cleanups
+
+### 01/24/10 11:51:54 changed by scop {#comment:1}
+
+-   **type** changed from *defect* to *enhancement*.
+
+### 01/25/10 10:37:05 changed by pmatilai {#comment:2}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+\...and applied. Thanks for the patch.
+
+### 01/25/10 10:37:16 changed by pmatilai {#comment:3}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+### 03/03/10 02:09:45 changed by Anonymous {#comment:4}
+
+-   **priority** changed from *trivial* to *minor*.
+-   **status** changed from *closed* to *reopened*.
+-   **resolution** deleted.
+
+There is still a remaining problem with this patch. The pattern in line
+85 of perl.req will match anything starting with some kind of quote
+character and ending with the same quote. But that might inappropriately
+include some extra copies of the same quote. For instance, if the source
+text in the file is:
+
+    $make_frag .= <<'MAKE_FRAG' if $self->is_make_type('dmake');
+
+then this is what will match and be treated as the tag:
+
+    MAKE_FRAG' if $self->is_make_type('dmake
+
+which is clearly not what what was intended. The string-content pattern
+matching needs to be changed to be not-greedy:
+
+    m/^\s*\$(?:.*)\s*=\s*<<\s*(["'`])(.*?)\1/
+
+### 03/03/10 18:49:33 changed by scop {#comment:5}
+
+Hm, I don\'t see how it would be a problem with this patch - this patch
+does not do any functional changes, it\'s just cleanup. This would be
+closer (but the problem is not introduced by it either):
+[https://bugzilla.redhat.com/attachment.cgi?id=362125&action=diff](https://web.archive.org/web/20151210102347/https://bugzilla.redhat.com/attachment.cgi?id=362125&action=diff)
+
+Anyway, your suggestion makes sense as a further improvement. I suppose
+while at it the last parenthesis should be changed from \* to + because
+something is always wanted between the quotes, ditto on the next line
+for \\w, no?
+
+### 03/03/10 18:51:17 changed by scop {#changed-by-scop-1}
+
+-   **attachment**
+    *0002-More-here-doc-skipping-fixes-for-perl.req-128.patch* added.
+
+More here-doc skipping fixes as discussed
+
+### 03/24/10 08:34:11 changed by pmatilai {#comment:6}
+
+-   **status** changed from *reopened* to *closed*.
+-   **resolution** set to *fixed*.
+
+Second patch also applied now, thanks.

--- a/ticket/136.md
+++ b/ticket/136.md
@@ -1,0 +1,193 @@
+---
+lang: en
+title: '\#136 (\[PATCH\] Extract interpreter dependencies from
+  \#!/usr/bin/env scripts.) - rpm - Trac'
+---
+
+Ticket \#136 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 8 months ago
+
+\[PATCH\] Extract interpreter dependencies from \#!/usr/bin/env scripts.
+------------------------------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Here\'s one possible approach to extract interpreter dependencies from
+\"\#!/usr/bin/env foo\" scripts, to be applied over the patches in
+[\#134](134 "[PATCH] Allow whitespace between #! and the interpreter. (closed)")
+and
+[\#135](135 "[PATCH] Emit dependencies only to interpreters with absolute paths. (closed)").
+
+The first added sed line finds /usr/bin/foo from \"\#!/usr/bin/env
+/usr/bin/foo\" (however useless using /usr/bin/env that way might be)
+and should be uncontroversial.
+
+The 2nd sed line and the path loop might be a bit controversial but is
+the first straightforward implementation that I thought of; for relative
+things like \"foo\" in \"\#!/usr/bin/env foo\" it checks if the \"foo\"
+executable is in some of \"rpm managed\" dirs that are assumed to be in
+all users\' \$PATH and emits a dependency on the first found such one.
+
+Attachments
+-----------
+
+[0008-Extract-interpreter-dependencies-from-usr-bin-env-sc.patch](/attachment/ticket/136/0008-Extract-interpreter-dependencies-from-usr-bin-env-sc.patch "View attachment")
+(1.3 kB) - added by *scop* on 02/10/10 21:19:54.
+
+Change History
+--------------
+
+### 02/10/10 21:19:54 changed by scop
+
+-   **attachment**
+    *0008-Extract-interpreter-dependencies-from-usr-bin-env-sc.patch*
+    added.
+
+### (follow-up: [[↓ 2]{.small}](#comment:2) ) 02/11/10 15:16:16 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+The normal case of non-absolute path is tricky as there\'s no guarantee
+that the interpreter exists on the build host. One possibility could be
+adding a special interpreter() dependency for it, ie \"\#!/usr/bin/env
+foo\" would turn into
+
+> /usr/bin/env interpreter(foo)
+
+The downside is of course that I dont see a sane way to automatically
+add the matching interpreter() provides :-/
+
+Didn\'t apply yet, I suspect this needs further head-scratching.
+
+### (in reply to: [[↑ 1]{.small}](#comment:1) ; follow-ups: [[↓ 3]{.small}](#comment:3) [[↓ 4]{.small}](#comment:4) ) 02/15/10 20:33:09 changed by scop {#comment:2}
+
+Replying to [pmatilai](136#comment:1 "Comment 1 for ticket:136"):
+
+> The normal case of non-absolute path is tricky as there\'s no
+> guarantee that the interpreter exists on the build host.
+
+Right, but packagers could have the package as
+[BuildRequires?](/BuildRequires)\... but yep, that\'s somewhat
+cumbersome. But I\'d like to point out that I think this is not that
+different from say automatic python byte-compilation which is a bit of
+an apples to oranges comparison but somewhat related anyway - one needs
+to have python installed for that to happen, and rpm-build does not have
+a dependency on python.
+
+BTW for the things in /usr/bin that use /usr/bin/env I have on my F-12
+box (a2x, asciidoc, asciidoc.py, bshdoc, gpsprof, hg-ssh,
+mercurial-convert-repo, rsvg) all ones using relative paths would be
+handled fine without additional [BuildRequires?](/BuildRequires) just
+for the interpreter package, it\'s [BuildRequired?](/BuildRequired)
+already anyway due to other reasons based on a quick lookup (caveat:
+\*quick\*; could be I missed something). bshdoc uses an absolute path
+(\"\#!/usr/bin/env /usr/bin/bsh\") and handling of that is also
+implemented by this patch (and I think that part of the patch could be
+safely applied in any case).
+
+> Didn\'t apply yet, I suspect this needs further head-scratching.
+
+Sure, take your time. And no problem if you end up scratching it.
+
+You probably already realized it but if the path based approach in the
+patch is taken, in case an interpreter moves from /usr/bin to /bin or
+vice versa without a compatibility symlink or something like that the
+dependency will break. So maybe just do it for /usr/bin and forget about
+the rest\...
+
+### (in reply to: [[↑ 2]{.small}](#comment:2) ) 02/15/10 20:35:10 changed by scop {#comment:3}
+
+Replying to [scop](136#comment:2 "Comment 2 for ticket:136"):
+
+> You probably already realized it but if the path based approach in the
+> patch is taken, in case an interpreter moves from /usr/bin to /bin or
+> vice versa without a compatibility symlink or something like that the
+> dependency will break.
+
+(\...even though the actual script using it with /usr/bin/env and a
+non-absolute path would not break.)
+
+### (in reply to: [[↑ 2]{.small}](#comment:2) ) 02/17/10 09:04:19 changed by pmatilai {#comment:4}
+
+Replying to [scop](136#comment:2 "Comment 2 for ticket:136"):
+
+> BTW for the things in /usr/bin that use /usr/bin/env I have on my F-12
+> box (a2x, asciidoc, asciidoc.py, bshdoc, gpsprof, hg-ssh,
+> mercurial-convert-repo, rsvg) all ones using relative paths would be
+> handled fine without additional [BuildRequires?](/BuildRequires) just
+> for the interpreter package, it\'s [BuildRequired?](/BuildRequired)
+> already anyway due to other reasons based on a quick lookup (caveat:
+> \*quick\*; could be I missed something).
+
+Nod, in practise mapping non-absolute \"env interpreters\" to /usr/bin/
+would work for vast majority of cases.
+
+> bshdoc uses an absolute path (\"\#!/usr/bin/env /usr/bin/bsh\") and
+> handling of that is also implemented by this patch (and I think that
+> part of the patch could be safely applied in any case).
+
+Yes, that part is obviously correct and will apply.
+
+> > Didn\'t apply yet, I suspect this needs further head-scratching.
+>
+> Sure, take your time. And no problem if you end up scratching it. You
+> probably already realized it but if the path based approach in the
+> patch is taken, in case an interpreter moves from /usr/bin to /bin or
+> vice versa without a compatibility symlink or something like that the
+> dependency will break. So maybe just do it for /usr/bin and forget
+> about the rest\...
+
+Yup. The path based approach would likely work in practise fairly well,
+but \"correct\" it is not.
+
+One (somewhat crazy) idea to determine interpreters automatically, with
+pathless interepreter(foo) style provides: whenever interpreter
+dependencies are present in the package being built (possibly including
+scriptlet interpreters), see if the interpreter path is in the current
+package. If found, then we know the path is used as an interpreter and
+we can add interpreter(basename) provide for it. For added bonus, add
+provides for symlinks and hardlinks to the file too. It shouldn\'t find
+any false positives but considering how easily it would break (some
+script is no longer shipped with a package and poof, there goes the
+interpreter provide), it\'s probably not worth the trouble.
+
+I\'m in middle of reworking the dependency generator internals atm, one
+of the things that\'s going to be added is additional path-based
+\"coloring\" using regexes (eventually to be read from configuration
+instead of being hardcoded in rpmfc.c), eg
+
+        { "^/usr/lib(64)?/python[[:digit:]]\\.[[:digit:]]/.*\\.(py|pyc|pyo)$", RPMFC_PYTHON },
+        /* We want to grab the version we're building now, %{__python} wont do */
+        { "^%{_bindir}/python[[:digit:]]\\.[[:digit:]]$", RPMFC_PYTHON },
+        { NULL, 0 },
+
+\...which would also allow marking various things as interpreters,
+something like:
+
+        { "^/bin/(da|ba|k|tc)?sh$", RPMFC_INTERPRETER },
+
+\...but the obvious downside is that somebody somewhere needs to add
+such entry for any new interepreter, so the advantage over telling
+packagers to just add \"Provides: interpreter(foo)\" to their packages
+is questionable.
+
+### 04/24/15 08:03:57 changed by FlorianFesti {#comment:5}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+RPM uses a simplified version of this that does not try to evaluate to
+the full patch for quite a while now. Guess we stay with this. Closing.

--- a/ticket/137.md
+++ b/ticket/137.md
@@ -1,0 +1,55 @@
+---
+lang: en
+title: '\#137 (\[PATCH\] use the right variable for absolute path) - rpm
+  - Trac'
+---
+
+Ticket \#137 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 5 years ago
+
+\[PATCH\] use the right variable for absolute path
+--------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   agriffis   Assigned to:   RpmTickets
+  Priority:      minor      Milestone:     rpm-4.9.0
+  Component:     rpm        Version:       RPM Development
+  Keywords:      patch      Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+Patch attached to fix the problem where rpm attempts to use the tarball
+as the specfile. This is due to a simple coding error.
+
+    $ /usr/bin/rpmbuild --define='_topdir work/foo' -ta work/foo-0.9.tar.gz 
+    error: File /home/agriffis/work/foo-0.9.tar.gz does not appear to be a specfile.
+
+Fixing this reveals other problems when dealing with relative paths, but
+the fix for this specific problem is obvious at least.
+
+Attachments
+-----------
+
+[80\_relative-tarball.patch](/attachment/ticket/137/80_relative-tarball.patch "View attachment")
+(318 bytes) - added by *agriffis* on 02/12/10 14:20:19.
+
+Change History
+--------------
+
+### 02/12/10 14:20:19 changed by agriffis
+
+-   **attachment** *80\_relative-tarball.patch* added.
+
+### 10/06/10 07:56:39 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.9.0*.
+
+Applied, thanks for the patch. And sorry about the ridiculous delay :-/

--- a/ticket/14.md
+++ b/ticket/14.md
@@ -1,0 +1,87 @@
+---
+lang: en
+title: '\#14 (\[PATCH\] Expose spec file headers in Python) - rpm -
+  Trac'
+---
+
+Ticket \#14 (closed enhancement: fixed)
+=======================================
+
+Opened 7 years ago
+
+Last modified 5 years ago
+
+\[PATCH\] Expose spec file headers in Python
+--------------------------------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   eswierk   Assigned to:   pmatilai
+  Priority:      major     Milestone:     rpm-4.9.0
+  Component:     rpm       Version:       RPM Development
+  Keywords:      Python    Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+It\'s nice to let the rpm library do the dirty work of parsing a spec
+file, but the Python library doesn\'t allow extracting information from
+the resulting headers. The attached patch remedies this with two new
+spec object methods: sourceHeader and packageHeaders.
+
+These methods return most of the same information you\'d get by building
+the package and reading the headers from the source rpm (sourceHeader)
+or binary rpms (packageHeaders).
+
+That\'s most, not all, because rpmbuild adds certain information to the
+headers when building a package, such as Provides for any .so files in a
+binary rpm. But for many applications, all the information you need is
+right there in the spec file, and these new methods give you a
+convenient way to access it from Python. For example:
+
+      import rpm
+      s = rpm.ts().parseSpec("foo.spec")
+      print s.sourceHeader()["name"]
+      print s.packageHeaders()[0]["name"]
+
+Attachments
+-----------
+
+[rpm-4.6.0-python-spec-headers.patch](/attachment/ticket/14/rpm-4.6.0-python-spec-headers.patch "View attachment") (2.0 kB) - added by *eswierk* on 12/10/08 07:24:34.
+:   Implement spec file header methods
+
+Change History
+--------------
+
+### 12/10/08 07:24:34 changed by eswierk
+
+-   **attachment** *rpm-4.6.0-python-spec-headers.patch* added.
+
+Implement spec file header methods
+
+### 12/18/08 08:47:17 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *assigned*.
+
+FYI, another patch towards the same goal was recently posted to
+rpm-maint list. The functionality is certainly welcome, I\'ll review the
+patches and merge either / best parts as soon as I find the time. In any
+case, thanks for the patch.
+
+### 02/23/09 14:46:46 changed by pmatilai {#comment:2}
+
+-   **keywords** set to *Python*.
+
+### 10/12/10 13:04:10 changed by pmatilai {#comment:3}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+This is finally fully implemented in HEAD. Access to binary headers
+through packages went in 4.8.0 but the source part was missing, some
+rationale behind that explained in
+[http://lists.rpm.org/pipermail/rpm-maint/2010-October/002889.html](https://web.archive.org/web/20150920122437/http://lists.rpm.org/pipermail/rpm-maint/2010-October/002889.html)
+
+### 10/12/10 13:04:28 changed by pmatilai {#comment:4}
+
+-   **milestone** set to *rpm-4.9.0*.

--- a/ticket/150.md
+++ b/ticket/150.md
@@ -1,0 +1,85 @@
+---
+lang: en
+title: '\#150 (mimetype provides generator should not process all
+  desktop files) - rpm - Trac'
+---
+
+Ticket \#150 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+mimetype provides generator should not process all desktop files
+----------------------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   stick   Assigned to:   RpmTickets
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Desktop file specification says:
+
+The [MimeType?](/MimeType) key is used to indicate the MIME Types that
+an application knows how to handle. It is expected that for some
+applications this list could become long. An application is expected to
+be able to reasonably open files of these types using the command listed
+in the Exec key.
+
+Therefore RPM should not process all desktop files, but only the ones
+that have Type=Application set. This could be further enhanced by
+requiring Exec= line to be present.
+
+Attachments
+-----------
+
+[rpm.patch](/attachment/ticket/150/rpm.patch "View attachment") (0.7 kB) - added by *llunak* on 03/17/10 14:43:08.
+:   rpm 4.7 patch
+
+[0001-Don-t-process-desktop-files-without-Type-Application.patch](/attachment/ticket/150/0001-Don-t-process-desktop-files-without-Type-Application.patch "View attachment") (1.0 kB) - added by *stick* on 03/17/10 15:05:27.
+:   patch against master
+
+Change History
+--------------
+
+### 03/17/10 14:43:08 changed by llunak
+
+-   **attachment** *rpm.patch* added.
+
+rpm 4.7 patch
+
+### 03/17/10 14:45:44 changed by llunak {#comment:1}
+
+I suggest the attached patch. It would also make sense to filter the
+locations of \*.desktop files that are checked (so that e.g. just
+example files shipped in a random location are ignored), but I don\'t
+know how to make sure that valid files are not ignored by this, as
+[http://standards.freedesktop.org/menu-spec/menu-spec-latest.html](https://web.archive.org/web/20151210102402/http://standards.freedesktop.org/menu-spec/menu-spec-latest.html)
+doesn\'t seem to provide an easy and reliable way to find all possible
+locations of application desktop files.
+
+### 03/17/10 15:05:27 changed by stick
+
+-   **attachment**
+    *0001-Don-t-process-desktop-files-without-Type-Application.patch*
+    added.
+
+patch against master
+
+### 05/04/10 09:55:36 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Apologies for the delay\... the patch against master applied now as it
+takes Exec presence into account too. Also the .desktop file locations
+are now filtered in the largely rewritten, pluggable (so things like
+this could actually be moved out of rpm) file classification system.
+
+Thanks for the patches :)

--- a/ticket/152.md
+++ b/ticket/152.md
@@ -1,0 +1,48 @@
+---
+lang: en
+title: '\#152 (\[PATCH\] Document deprecation of mi.count() and
+  ds.Count().) - rpm - Trac'
+---
+
+Ticket \#152 (closed enhancement: fixed)
+========================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+\[PATCH\] Document deprecation of mi.count() and ds.Count().
+------------------------------------------------------------
+
+  -------------- ------------ -------------- -----------------
+  Reported by:   scop         Assigned to:   RpmTickets
+  Priority:      trivial      Milestone:     
+  Component:     rpm-python   Version:       RPM Development
+  Keywords:                   Cc:            
+                                             
+  -------------- ------------ -------------- -----------------
+
+Attachments
+-----------
+
+[0003-Document-deprecation-of-mi.count-and-ds.Count.patch](/attachment/ticket/152/0003-Document-deprecation-of-mi.count-and-ds.Count.patch "View attachment")
+(1.4 kB) - added by *scop* on 03/19/10 18:11:37.
+
+Change History
+--------------
+
+### 03/19/10 18:11:37 changed by scop
+
+-   **attachment**
+    *0003-Document-deprecation-of-mi.count-and-ds.Count.patch* added.
+
+### 03/19/10 18:26:34 changed by scop {#comment:1}
+
+-   **component** changed from *rpm* to *rpm-python*.
+
+### 03/24/10 08:38:12 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied, thanks.

--- a/ticket/153.md
+++ b/ticket/153.md
@@ -1,0 +1,139 @@
+---
+lang: en
+title: '\#153 (Incompatible non-empty rpm.mi boolean value change in
+  4.8.0, len/count() issue) - rpm - Trac'
+---
+
+Ticket \#153 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Incompatible non-empty rpm.mi boolean value change in 4.8.0, len/count() issue
+------------------------------------------------------------------------------
+
+  -------------- ------------ -------------- -----------------
+  Reported by:   scop         Assigned to:   pmatilai
+  Priority:      major        Milestone:     
+  Component:     rpm-python   Version:       RPM Development
+  Keywords:                   Cc:            
+                                             
+  -------------- ------------ -------------- -----------------
+
+### Description {#comment:description}
+
+The following script demonstrates what I think are two problems with
+non-empty rpm.mi boolean value and len/count():
+
+    import rpm
+    ts = rpm.TransactionSet()
+    mi = ts.dbMatch()
+    mi.pattern("name", rpm.RPMMIRE_GLOB, "r*")
+    if mi:
+        print "mi true"
+    else:
+        print "mi false"
+    try:
+        print "len: %d" % len(mi)
+    except:
+        pass
+    print "count(): %d" % mi.count()
+    c = 0
+    for m in mi:
+        c += 1
+    print "real: %d" % c
+
+With 4.4.2.3 on CentOS 5 I get:
+
+    mi true
+    count(): 0
+    real: 15
+
+With 4.7.2 on Fedora 12 I get:
+
+    mi true
+    count(): 0
+    real: 37
+
+With 4.8.0 on Fedora 13 I get:
+
+    mi false
+    len: 0
+    count(): 0
+    real: 25
+
+Observations:
+
+-   The boolean value of non-empty mi changed incompatibly between 4.7.2
+    and 4.8.0 (breaks for example installed package globbing in rpmlint)
+-   I think both mi.count() and len(mi) are (and have been) somehow
+    broken in this case, they should return the same number as the
+    \"real\" IMO but return 0
+
+On the other hand, mi\'s returned from for example
+`ts.dbMatch("name", "rpm")` behave like I\'d expect in all these
+versions, both truth value and len/count() wise.
+
+Change History
+--------------
+
+### 03/20/10 10:42:46 changed by pmatilai {#comment:1}
+
+Hmm, the behavior change here is not intentional, I\'ll need to check
+where that comes from. The python bindings saw quite a churn between
+4.7.x and 4.8.x so, its more surprising that there has been so few
+(reported) breakages than the other way around :)
+
+The iterator count has always been rather broken (on C-level too): it
+only works on exact matches against index tags. Eg:
+
+> > > mi = ts.dbMatch(\'name\') mi.count()
+
+0
+
+> > > mi = ts.dbMatch(\'name\', \'kernel\') mi.count()
+
+3
+
+### 03/20/10 11:39:54 changed by pmatilai {#comment:2}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+Right\... this is the cause:
+[http://docs.python.org/library/stdtypes.html\#truth-value-testing](https://web.archive.org/web/20151210102412/http://docs.python.org/library/stdtypes.html#truth-value-testing)
+
+> instances of user-defined classes, if the class defines a nonzero() or
+> len() method, when that method returns the integer zero or bool value
+> False.
+
+Now that the iterator implements `__len__()`, that\'s what gets used for
+truth value whereas any mi instance previously always returned True,
+just like \"foo = object()\" evals to True. Reverting to former behavior
+is easily achieved by adding `__nonzero__()` which always returns True,
+which is probably the less surprising behavior, considering how unusable
+the `__len__()` method is due to its unreliability.
+
+### 03/21/10 20:46:49 changed by scop {#comment:3}
+
+Thanks for looking into this. Let me know if you find a \"fix\" and
+intend to ship it for Fedora 13 - I have a trivial fix for this already
+in rpmlint svn but won\'t bother shipping an update for this purpose if
+you intend to push a rpm update.
+
+### 03/24/10 08:20:29 changed by pmatilai {#comment:4}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Okay, fixed now:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=40f788a7bf3741f9c613ff302d4e1b0ceec2658c](https://web.archive.org/web/20151210102412/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=40f788a7bf3741f9c613ff302d4e1b0ceec2658c)
+
+This is not actually 100% identical behavior to pre-4.8.0 which returned
+True no matter what, whereas now the truth value actually sorta means
+something (you get False when it knows there are no matches at all)
+
+On the Fedora-side of things: fixed now in rawhide and will pull to F13
+in near future, there are a few other fixes pending for 13 too.

--- a/ticket/156.md
+++ b/ticket/156.md
@@ -1,0 +1,43 @@
+---
+lang: en
+title: '\#156 (rpm \--initdb does not create Names database) - rpm -
+  Trac'
+---
+
+Ticket \#156 (closed defect: fixed)
+===================================
+
+Opened 6 years ago
+
+Last modified 5 years ago
+
+rpm \--initdb does not create Names database
+--------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   RpmTickets
+  Priority:      major   Milestone:     rpm-4.9.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+The Names database is not created by rpm \--initdb and rpm later
+complains when it is not existing (no packages were installed, we\'re
+just getting information from existing rpm packages).
+
+Change History
+--------------
+
+### 10/18/10 15:13:50 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.9.0*.
+
+This got finally fixed in HEAD, \--initdb now initiates all the indexes
+too. Not initializing the indexes doesn\'t make much of a difference for
+\"normal\" rpm usage where the database is always populated but should
+hurt anything either, and it made sense for some other related items\...

--- a/ticket/157.md
+++ b/ticket/157.md
@@ -1,0 +1,104 @@
+---
+lang: en
+title: '\#157 (Permissions not attached to files in chroots) - rpm -
+  Trac'
+---
+
+Ticket \#157 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 2 years ago
+
+Permissions not attached to files in chroots
+--------------------------------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   jengelh   Assigned to:   pmatilai
+  Priority:      major     Milestone:     
+  Component:     rpm       Version:       RPM Development
+  Keywords:                Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+Installation with rpm \--root yields:
+
+/srv/nfs/base32\# linux32 rpm \--root \$PWD -Uhv
+cups-client-1.3.11-4.5.1.i586.rpm Preparing\...
+\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
+\[100%\]
+
+> 1:cups-client warning: user lp does not exist - using root( 26%)
+
+warning: group lp does not exist - using root
+\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
+\[100%\]
+
+And that despite lp existing in both /etc/{passwd,group} and
+/srv/nfs/base32/etc/{passwd,group}. Looks non-trivial. Any idea what
+could be done?
+
+Attachments
+-----------
+
+[strace.log](/attachment/ticket/157/strace.log "View attachment") (139.0
+kB) - added by *jengelh* on 05/18/10 12:33:21.
+
+[ts.spec](/attachment/ticket/157/ts.spec "View attachment") (173 bytes)
+- added by *jengelh* on 05/18/10 12:33:35.
+
+Change History
+--------------
+
+### 05/17/10 11:51:09 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+Basically that means getpwnam() is failing for whatever reason. Rpm
+(tries to) preload nss libraries before chroot() to ensure working name
+services inside chroots but maybe there\'s a new catch here or
+something\...
+
+Try to get a strace log of the thing, that should provide some clues to
+what\'s going on.
+
+### 05/18/10 12:32:34 changed by jengelh {#comment:2}
+
+It is reproducible using one\'s own system root itself, i.e.
+
+rpm \--root / -Uhv ts.rpm
+
+### 05/18/10 12:33:21 changed by jengelh {#changed-by-jengelh}
+
+-   **attachment** *strace.log* added.
+
+### 05/18/10 12:33:35 changed by jengelh {#changed-by-jengelh-1}
+
+-   **attachment** *ts.spec* added.
+
+### 05/19/10 13:04:51 changed by pmatilai {#comment:3}
+
+FWIW I can\'t reproduce this. ts.spec does complain about user sys not
+existing but rightfully so as on Fedora there\'s no such user (only
+group called \"sys\"), and using other user/group names doesn\'t change
+the situation. Need to dig into the strace\...
+
+### 05/19/10 13:24:11 changed by pmatilai {#comment:4}
+
+Looking at the strace log, this has to do with the host being configured
+to use LDAP for user information and the system not falling back to
+/etc/{passwd,group} when not found in LDAP.
+
+### 01/28/14 12:30:49 changed by pmatilai {#comment:5}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+This is likely to be the same issue as the one reported here:
+[http://lists.rpm.org/pipermail/rpm-maint/2014-January/003652.html](https://web.archive.org/web/20150920210905/http://lists.rpm.org/pipermail/rpm-maint/2014-January/003652.html)
+and should be fixed by this:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=abbf4897db217b4977b4c21eb09929c797ee015d](https://web.archive.org/web/20150920210905/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=abbf4897db217b4977b4c21eb09929c797ee015d)

--- a/ticket/158.md
+++ b/ticket/158.md
@@ -1,0 +1,61 @@
+---
+lang: en
+title: '\#158 (rpmbuild should error and/or toss out EMPTY
+  provides/requires/conflicts/obsoletes entries) - rpm - Trac'
+---
+
+Ticket \#158 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 1 year ago
+
+rpmbuild should error and/or toss out EMPTY provides/requires/conflicts/obsoletes entries
+-----------------------------------------------------------------------------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   skvidal   Assigned to:   pmatilai
+  Priority:      minor     Milestone:     rpm-4.12.0
+  Component:     rpm       Version:       RPM Development
+  Keywords:                Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+[https://bugzilla.redhat.com/show\_bug.cgi?id=473084](https://web.archive.org/web/20150924060616/https://bugzilla.redhat.com/show_bug.cgi?id=473084)
+
+somehow that pkg
+[http://kojipkgs.fedoraproject.org/packages/opal/3.4.2/1.fc10/i386/opal-3.4.2-1.fc10.i386.rpm](https://web.archive.org/web/20150924060616/http://kojipkgs.fedoraproject.org/packages/opal/3.4.2/1.fc10/i386/opal-3.4.2-1.fc10.i386.rpm)
+
+has an empty provides entry. I suspect it came from the find-provides
+script.
+
+This tripped up yum (this is now fixed in yum) but in general I think an
+empty provides is a bad idea.
+
+Change History
+--------------
+
+### 05/17/10 13:40:05 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+Ack, I can reproduce this easily enough by making library soname an
+empty string (instead of missing soname)
+
+### 01/24/14 13:08:43 changed by pmatilai {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed (finally!) by combination of
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=ee5a500fee1b96ab6d4acf091fdc9b8388a80c41](https://web.archive.org/web/20150924060616/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=ee5a500fee1b96ab6d4acf091fdc9b8388a80c41)
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=66a01c977ea198fb05c5df22013884a6973485c5](https://web.archive.org/web/20150924060616/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=66a01c977ea198fb05c5df22013884a6973485c5)
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=73bd9636d0e76a4d255776b7733667198b9ef585](https://web.archive.org/web/20150924060616/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=73bd9636d0e76a4d255776b7733667198b9ef585)
+
+### 09/16/14 11:07:58 changed by pmatilai {#comment:3}
+
+-   **milestone** set to *rpm-4.12.0*.

--- a/ticket/175.md
+++ b/ticket/175.md
@@ -1,0 +1,57 @@
+---
+lang: en
+title: '\#175 (Intermediate disk-space need not accounted for (eg on
+  reinstall)) - rpm - Trac'
+---
+
+Ticket \#175 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 3 years ago
+
+Intermediate disk-space need not accounted for (eg on reinstall)
+----------------------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   pmatilai   Assigned to:   RpmTickets
+  Priority:      minor      Milestone:     rpm-4.11.0
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+When calculating disk-space needs for a transaction, rpm currently
+doesn\'t take into account the amount of disk it temporarily needs for
+unpacking the files before moving into place. For example on package
+reinstall rpm thinks the transaction will succeed as it doesn\'t need
+any more space than the currently installed package, but when space is
+tight it can easily fail, eg:
+
+    # rpm -Uvh /home/pmatilai/rpmbuild/RPMS/noarch/dsneedtest-1.0-1.noarch.rpm
+    Preparing...                ########################################### [100%]
+       1:dsneedtest             ########################################### [100%]
+    # dd if=/dev/zero of=/boot/fillme
+    # rpm -Uvh --force dsneedtest-1.0-1.noarch.rpm
+    Preparing...                ########################################### [100%]
+       1:dsneedtest             ########################################### [100%]
+    error: unpacking of archive failed on file /boot/de.txt;4c5ffe6f: cpio: write
+    error: dsneedtest-1.0-1.noarch: install failed
+
+Change History
+--------------
+
+### 11/14/12 08:58:26 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Finally fixed in
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=85df102165fdbe64978f2019d757d400e7448218](https://web.archive.org/web/20151229075518/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=85df102165fdbe64978f2019d757d400e7448218)
+
+### 01/29/13 09:32:33 changed by pmatilai {#comment:2}
+
+-   **milestone** set to *rpm-4.11.0*.

--- a/ticket/2.md
+++ b/ticket/2.md
@@ -1,0 +1,67 @@
+---
+lang: en
+title: '\#2 (rpmbuild: Run rpmlint / another tool on generated RPMs) -
+  rpm - Trac'
+---
+
+Ticket \#2 (closed enhancement: fixed)
+======================================
+
+Opened 7 years ago
+
+Last modified 7 years ago
+
+rpmbuild: Run rpmlint / another tool on generated RPMs
+------------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   rwmjones   Assigned to:   jnovy
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+How many times have you copied and pasted the path names printed out by
+rpmbuild when it successfully builds RPMs, into another program such as
+rpmlint?
+
+    $ rpmbuild -ba foobar.spec
+    [...]
+    Wrote: foobar-1.0-1.src.rpm
+    Wrote: foobar-1.0-1.i386.rpm
+
+    $ rpmlint foobar-1.0-1.src.rpm foobar-1.0-1.i386.rpm
+
+What is needed is to have an rpmbuild option or some hook / macro that
+we can set so that rpmbuild automatically runs a user-defined program on
+the final RPMs.
+
+Change History
+--------------
+
+### 10/26/08 13:28:26 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *assigned*.
+
+### 11/03/08 12:36:02 changed by jnovy {#comment:2}
+
+-   **owner** changed from *pmatilai* to *jnovy*.
+-   **status** changed from *assigned* to *new*.
+
+Taking this one, sounds reasonable.
+
+### 11/03/08 12:36:18 changed by jnovy {#comment:3}
+
+-   **status** changed from *new* to *assigned*.
+
+### 11/10/08 15:56:57 changed by jnovy {#comment:4}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+The enhancement is now implemented and comitted. Please get the latest
+git rpm to give it a try :) Usage is well described in the commit
+messages.

--- a/ticket/25.md
+++ b/ticket/25.md
@@ -1,0 +1,44 @@
+---
+lang: en
+title: '\#25 (Type set by tag extensions not honored in queryformat) -
+  rpm - Trac'
+---
+
+Ticket \#25 (closed defect: fixed)
+==================================
+
+Opened 7 years ago
+
+Last modified 7 years ago
+
+Type set by tag extensions not honored in queryformat
+-----------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   pmatilai   Assigned to:   pmatilai
+  Priority:      minor      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+    $ rpm -q --fileclass telnet
+    /usr/bin/telnet 0
+    /usr/share/man/man1/telnet.1.gz 0
+
+This got broken by the rpmtag/rpmtd class stuff, at least in case of
+RPMTAG\_FILECLASS the real tag is integer type but the extension is a
+string array, rpmtdClass() gets this wrong by using rpmTagGetClass()
+causing it to think it\'s dealing with integers.
+
+Change History
+--------------
+
+### 01/28/09 11:27:34 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Got around to fix this sooner than I thought\...

--- a/ticket/26.md
+++ b/ticket/26.md
@@ -1,0 +1,51 @@
+---
+lang: en
+title: '\#26 (Space used by rpmdb not accounted at all in disk space
+  checking) - rpm - Trac'
+---
+
+Ticket \#26 (closed enhancement: fixed)
+=======================================
+
+Opened 7 years ago
+
+Last modified 5 years ago
+
+Space used by rpmdb not accounted at all in disk space checking
+---------------------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   pmatilai   Assigned to:   FlorianFesti
+  Priority:      minor      Milestone:     rpm-4.9.0
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+When doing disk space calculations, only files from payload are
+considered. The rpmdb can grow considerably in large transactions (tens
+of megabytes easily), which isn\'t estimated in any way. Doesn\'t matter
+normally but when space gets tight, it can become an issue. Would be
+good to throw in *some* estimate for the rpmdb part, size of header
+times three or something.
+
+Change History
+--------------
+
+### 02/01/10 16:00:36 changed by FlorianFesti {#comment:1}
+
+-   **owner** changed from *pmatilai* to *FlorianFesti*.
+
+### 02/05/10 14:17:18 changed by FlorianFesti {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed in
+[9068da47a912a6983a12d1024a118c16bcb2a057](https://github.com/rpm-software-management/rpm/commit/9068da47a912a6983a12d1024a118c16bcb2a057 "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.")
+
+### 10/06/10 07:12:06 changed by pmatilai {#comment:3}
+
+-   **milestone** set to *rpm-4.9.0*.

--- a/ticket/39.md
+++ b/ticket/39.md
@@ -1,0 +1,263 @@
+---
+lang: en
+title: '\#39 (Fix some bug in osgideps.pl script) - rpm - Trac'
+---
+
+Ticket \#39 (closed defect: fixed)
+==================================
+
+Opened 7 years ago
+
+Last modified 6 years ago
+
+Fix some bug in osgideps.pl script
+----------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   alcapcom   Assigned to:   pmatilai
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+The patch fixe follow bugs:\
+- use Temp perl module to provide temp dir\
+- re-enable deps solving in Require-Bundle, Import-Package,
+Export-Package OSGI properties\
+- Remove uses bundle of Export-Package OSGI property\
+- use RPM \'\>=\' as version operator to match OSGI \'=\'\
+- remove all .0 at the end of the version string\
+- Some typo changes\
+\
+I\'ve also wrote a little script to debug osgideps.pl script on a given
+list of file, the script check if all requires are provided and that
+versions match correctly. Result of it all Fedora Eclipse packages files
+enlighten that we are short of a stable release.\
+\
+command: rpm-osgideps-check \--command=\"rpm -ql \$(rpm -qa \| grep
+eclipse)\"\
+\
+installed packages (rpm -qa \| grep eclipse):\
+eclipse-rcp-3.4.1-5.fc10.x86\_64\
+eclipse-pde-3.4.1-5.fc10.x86\_64\
+eclipse-cdt-5.0.1-2.fc10.x86\_64\
+eclipse-ecj-3.4.1-5.fc10.x86\_64\
+eclipse-mylyn-java-3.0.3-3.fc10.noarch\
+eclipse-subclipse-1.2.4-12.fc10.noarch\
+eclipse-pydev-1.4.2-1.fc10.x86\_64\
+eclipse-changelog-2.6.6-1.fc10.x86\_64\
+eclipse-rpm-editor-0.4.0-5.fc10.x86\_64\
+eclipse-quickrex-3.5.0-9.fc10.noarch\
+eclipse-swt-3.4.1-5.fc10.x86\_64\
+eclipse-platform-3.4.1-5.fc10.x86\_64\
+eclipse-mylyn-3.0.3-3.fc10.noarch\
+tomcat5-jasper-eclipse-5.5.27-6.1.fc10.noarch\
+eclipse-nls-fr-0.2.0-0.5.20080807snap.fc10.noarch\
+icu4j-eclipse-3.8.1-4.fc10.x86\_64\
+eclipse-jdt-3.4.1-5.fc10.x86\_64\
+\
+Bundles required but provide by the JVM as OSGI system package:\
+osgi(javax.crypto)\
+osgi(javax.crypto.spec)\
+osgi(javax.net)\
+osgi(javax.net.ssl)\
+osgi(javax.security.auth)\
+osgi(javax.security.auth.callback)\
+osgi(javax.security.auth.login)\
+osgi(javax.security.auth.spi)\
+osgi(javax.security.auth.x500)\
+osgi(javax.security.cert)\
+osgi(javax.xml.parsers)\
+osgi(javax.xml.transform)\
+osgi(javax.xml.transform.dom)\
+osgi(javax.xml.transform.stream)\
+osgi(org.w3c.dom)\
+osgi(org.xml.sax)\
+osgi(org.xml.sax.ext)\
+osgi(org.xml.sax.helpers)\
+\
+Not provided OSGI required bundles:\
+Bundles: osgi(org.apache.derby), osgi(org.apache.derby.core),
+osgi(Cloudscape)\
+Files:
+/usr/lib64/eclipse/dropins/sdk/plugins/org.eclipse.test.performance\_3.4.0.v20080507.jar\
+\
+Bundles: osgi(org.apache.xerces)\
+Files:
+/usr/share/eclipse/dropins/mylyn-webtasks/eclipse/plugins/org.jdom\_1.0.0.v200806100616.jar\
+/usr/share/eclipse/dropins/epic/eclipse/plugins/org.epic.lib\_0.6.1/lib/jdom.jar\
+
+Attachments
+-----------
+
+[osgideps.pl-2009-02-03.patch](/attachment/ticket/39/osgideps.pl-2009-02-03.patch "View attachment") (3.3 kB) - added by *alcapcom* on 03/02/09 10:19:45.\
+[rpm-osgideps-check](/attachment/ticket/39/rpm-osgideps-check "View attachment") (3.2 kB) - added by *alcapcom* on 03/02/09 10:21:08.\
+[osgideps.pl.patch](/attachment/ticket/39/osgideps.pl.patch "View attachment") (3.8 kB) - added by *alcapcom* on 03/03/09 19:10:28.\
+[eclipse.spec.patch](/attachment/ticket/39/eclipse.spec.patch "View attachment") (3.0 kB) - added by *alcapcom* on 03/06/09 10:52:46.
+:   eclipse.spec.patch 2007-03-06
+
+[osgideps.pl.2.patch](/attachment/ticket/39/osgideps.pl.2.patch "View attachment") (3.6 kB) - added by *alcapcom* on 03/06/09 10:53:25.
+:   osgideps.pl.patch 2007-03-06
+
+[osgideps.pl.patch.20090617](/attachment/ticket/39/osgideps.pl.patch.20090617 "View attachment") (15.1 kB) - added by *alcapcom* on 06/17/09 11:55:23.
+:   osgideps.pl.patch
+
+Change History
+--------------
+
+### 03/02/09 10:19:45 changed by alcapcom
+
+-   **attachment** *osgideps.pl-2009-02-03.patch* added.
+
+### 03/02/09 10:21:08 changed by alcapcom
+
+-   **attachment** *rpm-osgideps-check* added.
+
+### 03/02/09 11:27:08 changed by alcapcom {#comment:1}
+
+Oups the current list of installed package is:\
+
+eclipse-emf-sdo-2.4.1-4.fc10.noarch\
+eclipse-phpeclipse-1.2.1-2.fc10.x86\_64\
+eclipse-egit-0.4.0-1.fc10.noarch\
+eclipse-emf-2.4.1-4.fc10.noarch\
+eclipse-photran-xlf-4.0.0-0.b4.fc10.3.x86\_64\
+eclipse-cdt-mylyn-5.0.1-2.fc10.x86\_64\
+eclipse-rcp-3.4.1-5.fc10.x86\_64\
+eclipse-pde-3.4.1-5.fc10.x86\_64\
+eclipse-cdt-5.0.1-2.fc10.x86\_64\
+eclipse-ecj-3.4.1-5.fc10.x86\_64\
+eclipse-mylyn-java-3.0.3-3.fc10.noarch\
+eclipse-subclipse-1.2.4-12.fc10.noarch\
+eclipse-pydev-1.4.2-1.fc10.x86\_64\
+eclipse-changelog-2.6.6-1.fc10.x86\_64\
+eclipse-gef-examples-3.4.1-2.fc10.x86\_64\
+eclipse-demos-0.0.1-2.fc8.noarch\
+eclipse-cdt-sdk-5.0.1-2.fc10.x86\_64\
+eclipse-pydev-mylyn-1.4.2-1.fc10.x86\_64\
+eclipse-rpm-editor-0.4.0-5.fc10.x86\_64\
+eclipse-quickrex-3.5.0-9.fc10.noarch\
+eclipse-photran-4.0.0-0.b4.fc10.3.x86\_64\
+eclipse-slide-1.3.11-3.fc10.noarch\
+eclipse-mylyn-trac-3.0.3-3.fc10.noarch\
+eclipse-swt-3.4.1-5.fc10.x86\_64\
+eclipse-platform-3.4.1-5.fc10.x86\_64\
+eclipse-mylyn-webtasks-3.0.3-3.fc10.noarch\
+eclipse-shelled-1.0.4-1.fc10.noarch\
+eclipse-mylyn-3.0.3-3.fc10.noarch\
+tomcat5-jasper-eclipse-5.5.27-6.1.fc10.noarch\
+eclipse-gef-3.4.1-2.fc10.x86\_64\
+eclipse-emf-sdk-2.4.1-4.fc10.noarch\
+eclipse-emf-xsd-sdk-2.4.1-4.fc10.noarch\
+eclipse-checkstyle-4.0.1-11.fc10.x86\_64\
+eclipse-emf-examples-2.4.1-4.fc10.noarch\
+eclipse-subclipse-book-1.2.4-12.fc10.noarch\
+eclipse-mylyn-pde-3.0.3-3.fc10.noarch\
+eclipse-gef-sdk-3.4.1-2.fc10.x86\_64\
+eclipse-emf-sdo-sdk-2.4.1-4.fc10.noarch\
+icu4j-eclipse-3.8.1-4.fc10.x86\_64\
+eclipse-jdt-3.4.1-5.fc10.x86\_64\
+eclipse-epic-0.6.27-1.fc10.x86\_64\
+eclipse-emf-xsd-2.4.1-4.fc10.noarch\
+eclipse-setools-3.3.2.4-3.fc10.x86\_64\
+
+### 03/03/09 19:10:28 changed by alcapcom {#changed-by-alcapcom-2}
+
+-   **attachment** *osgideps.pl.patch* added.
+
+### 03/03/09 20:01:17 changed by alcapcom {#comment:2}
+
+Hi,
+
+The last patch fix two other bugs\[1\], we currently completely ignore
+optional requires, should that be true in the future?\... in other word
+any plan to support optional deps :)
+
+Panu, we need this patch in rawhide (sooner as possible of course), do
+you prefer that I open a bug there too?
+
+\[1\] we don\'t require or provide optional bundles, we no more touch
+version strings.
+
+Thanks
+
+### 03/06/09 10:52:46 changed by alcapcom {#changed-by-alcapcom-3}
+
+-   **attachment** *eclipse.spec.patch* added.
+
+eclipse.spec.patch 2007-03-06
+
+### 03/06/09 10:53:25 changed by alcapcom {#changed-by-alcapcom-4}
+
+-   **attachment** *osgideps.pl.2.patch* added.
+
+osgideps.pl.patch 2007-03-06
+
+### 03/06/09 10:57:16 changed by alcapcom {#comment:3}
+
+Oups, don\'t take in account eclipse.spec patch, it\'s just a false
+manipulation.
+
+2007-03-06 patch Also remove x-friends bundles of OSGI Export-Packages
+(RPM requires)
+
+Regards, Alphonse
+
+### 06/17/09 11:55:23 changed by alcapcom {#changed-by-alcapcom-5}
+
+-   **attachment** *osgideps.pl.patch.20090617* added.
+
+osgideps.pl.patch
+
+### 06/17/09 12:01:36 changed by alcapcom {#comment:4}
+
+Last patch fix a lot of bug and typo errors, based on some test that I
+have do with this script, it sound good for production.
+
+Please apply it ASAP.
+
+Have a good day, Alphonse
+
+### (follow-up: [[↓ 6]{.small}](#comment:6) ) 06/18/09 09:19:37 changed by pmatilai {#comment:5}
+
+-   **status** changed from *new* to *assigned*.
+
+Hmm, I\'m getting a bit lost in the patches :) Just to make sure: the
+osgideps.pl.patch.20090617 is the only one of these that should be
+applied, right?
+
+### (in reply to: [[↑ 5]{.small}](#comment:5) ) 06/18/09 09:56:06 changed by alcapcom {#comment:6}
+
+Replying to [pmatilai](39#comment:5 "Comment 5 for ticket:39"):
+
+> Hmm, I\'m getting a bit lost in the patches :)
+
+:)
+
+> Just to make sure: the osgideps.pl.patch.20090617 is the only one of
+> these that should be applied, right?
+
+Yes only that one
+
+Thanks
+
+### 06/18/09 10:10:30 changed by pmatilai {#comment:7}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Okay, applied now, thanks for the patch. Or actually git thinks it\'s a
+rewrite :)
+
+> 1 files changed, 357 insertions(+), 203 deletions(-) rewrite
+> scripts/osgideps.pl (91%)
+
+### 06/18/09 11:10:25 changed by alcapcom {#comment:8}
+
+Yeah, indentation rework + some new functions = completely new script
+for a scim :)
+
+Thanks to apply it so quickly.

--- a/ticket/41.md
+++ b/ticket/41.md
@@ -1,0 +1,43 @@
+---
+lang: en
+title: '\#41 (Use content format that supports large files) - rpm -
+  Trac'
+---
+
+Ticket \#41 (closed enhancement: fixed)
+=======================================
+
+Opened 7 years ago
+
+Last modified 1 year ago
+
+Use content format that supports large files
+--------------------------------------------
+
+  -------------- ----------------- -------------- -----------------
+  Reported by:   FlorianFesti      Assigned to:   pmatilai
+  Priority:      major             Milestone:     rpm-4.12.0
+  Component:     rpm               Version:       RPM Development
+  Keywords:      cpio large file   Cc:            
+                                                  
+  -------------- ----------------- -------------- -----------------
+
+### Description {#comment:description}
+
+While rpm can handle large files internally the content is still put
+into a cpio archive which is limited to files \< 4GB.
+
+To solve that another archive format needs to be chosen and supported.
+
+This is going to break forward compatibility.
+
+Change History
+--------------
+
+### 09/08/14 08:51:32 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.12.0*.
+
+Fixed in 4.12.0, by yourself in case you\'ve forgotten ;)

--- a/ticket/45.md
+++ b/ticket/45.md
@@ -1,0 +1,58 @@
+---
+lang: en
+title: '\#45 (Implement dynamic macro expansion) - rpm - Trac'
+---
+
+Ticket \#45 (closed defect: fixed)
+==================================
+
+Opened 7 years ago
+
+Last modified 5 years ago
+
+Implement dynamic macro expansion
+---------------------------------
+
+  -------------- -------------- -------------- -----------------
+  Reported by:   FlorianFesti   Assigned to:   pmatilai
+  Priority:      minor          Milestone:     rpm-4.9.0
+  Component:     rpm            Version:       RPM Development
+  Keywords:                     Cc:            
+                                               
+  -------------- -------------- -------------- -----------------
+
+### Description {#comment:description}
+
+current implementation passes fixed sized buffers to expand macros
+
+Change History
+--------------
+
+### 03/05/09 13:18:52 changed by FlorianFesti {#comment:1}
+
+-   **milestone** set to *rpm-4.8.0*.
+
+### 04/22/09 08:16:30 changed by FlorianFesti {#comment:2}
+
+-   **milestone** deleted.
+
+### 10/06/10 07:09:00 changed by pmatilai {#comment:3}
+
+-   **status** changed from *new* to *assigned*.
+-   **milestone** set to *rpm-4.9.0*.
+
+This has been implemented in the macro engine itself as of commit
+[49f99b86566bf71e1ebd8be4da29953aaf042b79](https://github.com/rpm-software-management/rpm/commit/49f99b86566bf71e1ebd8be4da29953aaf042b79 "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.").
+However the spec parser still uses the older expandMacros() API which is
+limited by caller-specified preallocated buffer. As rpmExpand() doesn\'t
+return error codes, a new API is needed to take advantage of the dynamic
+buffer expansion in the spec parser.
+
+### 01/05/11 06:54:40 changed by pmatilai {#comment:4}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Considering this done, the spec parser part is tracked separately in
+ticket
+[\#814](/web/20151019213648/http://rpm.org/ticket/814 "Eliminate static buffer from spec parsing (new)").

--- a/ticket/47.md
+++ b/ticket/47.md
@@ -1,0 +1,64 @@
+---
+lang: en
+title: '\#47 (RFE: Add global macro to limit changelog in binary
+  packages) - rpm - Trac'
+---
+
+Ticket \#47 (closed enhancement: fixed)
+=======================================
+
+Opened 7 years ago
+
+Last modified 5 years ago
+
+RFE: Add global macro to limit changelog in binary packages
+-----------------------------------------------------------
+
+  -------------- -------------- -------------- -----------------
+  Reported by:   FlorianFesti   Assigned to:   jnovy
+  Priority:      minor          Milestone:     rpm-4.8.0
+  Component:     rpm            Version:       RPM Development
+  Keywords:                     Cc:            
+                                               
+  -------------- -------------- -------------- -----------------
+
+### Description {#comment:description}
+
+To save space in the packages and the rpmdb a macro could limit the
+changelog in binary packages. That way ancient log entries could still
+be looked up in the spec file. Limit could be done by \#entries or by
+time or both.
+
+Change History
+--------------
+
+### 03/05/09 14:34:05 changed by FlorianFesti {#comment:1}
+
+-   **milestone** set to *rpm-4.7.0*.
+
+### 04/16/09 07:44:52 changed by FlorianFesti {#comment:2}
+
+-   **milestone** changed from *rpm-4.7.0* to *rpm-4.8.0*.
+
+### 04/16/09 07:47:53 changed by jnovy {#comment:3}
+
+-   **owner** changed from *pmatilai* to *jnovy*.
+
+### 04/16/09 12:20:34 changed by jnovy {#comment:4}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+The new changelog trimming feature is now implemented upstream. The
+current implementation allows changelog trimming based on changelog
+entry date. It is specified via \_changelog\_trimtime macro:
+
+\# The Unix time of the latest kept changelog entry in binary packages.\
+\# Any older entry is not packaged in binary packages.\
+%\_changelog\_trimtime 0
+
+### 08/10/10 15:16:08 changed by wis3384 {#comment:5}
+
+> [htc evo
+> cases](https://web.archive.org/web/20150920122441/http://htcevo4gcase.com/)
+> Changed 1 year ago by admin

--- a/ticket/48.md
+++ b/ticket/48.md
@@ -1,0 +1,39 @@
+---
+lang: en
+title: '\#48 (Implement erasure ordering) - rpm - Trac'
+---
+
+Ticket \#48 (closed defect: fixed)
+==================================
+
+Opened 7 years ago
+
+Last modified 6 years ago
+
+Implement erasure ordering
+--------------------------
+
+  -------------- -------------- -------------- -----------------
+  Reported by:   FlorianFesti   Assigned to:   FlorianFesti
+  Priority:      major          Milestone:     rpm-4.8.0
+  Component:     rpm            Version:       RPM Development
+  Keywords:      ordering       Cc:            
+                                               
+  -------------- -------------- -------------- -----------------
+
+### Description {#comment:description}
+
+Right now only installs are ordered correctly. This can lead to problems
+with post scripts.
+
+Change History
+--------------
+
+### 04/15/09 11:19:02 changed by FlorianFesti {#comment:1}
+
+-   **owner** changed from *pmatilai* to *FlorianFesti*.
+
+### 04/15/09 11:19:14 changed by FlorianFesti {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.

--- a/ticket/5.md
+++ b/ticket/5.md
@@ -1,0 +1,73 @@
+---
+lang: en
+title: '\#5 (rpm fails with \"cannot open Packages database\") - rpm -
+  Trac'
+---
+
+Ticket \#5 (closed defect: fixed)
+=================================
+
+Opened 7 years ago
+
+Last modified 7 years ago
+
+rpm fails with \"cannot open Packages database\"
+------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   atkac   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+rpm -i \<package\> fails with \"cannot open Packages database\" error on
+GNU/Hurd system. After quick debugging problem is in
+rpmdb.c:openDatabase function. It has this code there:
+
+if (mode & O\_WRONLY)
+
+> return 1;
+
+Main problem is that GNU/Hurd has this O\_RDWR definition:
+
+\#define O\_RDWR (O\_RDONLY\|O\_WRONLY)
+
+so rpm fails even if O\_RDWR is set. POSIX says:
+
+\"In historical implementations the value of O\_RDONLY is zero. Because
+of that, it is not possible to detect the presence of O\_RDONLY and
+another option. Future implementations should encode O\_RDONLY and
+O\_WRONLY as bit flags so that:
+
+O\_RDONLY \| O\_WRONLY == O\_RDWR \"
+
+I\'m not sure what will be the proper patch because Linux has O\_RDONLY
+== 0. It seems that \"\#ifdef linux\" will help or that condition will
+be eliminated.
+
+Change History
+--------------
+
+### 11/03/08 17:51:19 changed by atkac {#comment:1}
+
+Better fix is suggested on
+[http://lists.gnu.org/archive/html/bug-hurd/2008-11/msg00021.html](https://web.archive.org/web/20150920070321/http://lists.gnu.org/archive/html/bug-hurd/2008-11/msg00021.html)
+
+### 11/03/08 19:00:17 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *assigned*.
+
+Ok, that\'s a nice one, will do - there are a few other places in rpm
+that need a similar change.
+
+### 11/04/08 08:01:50 changed by pmatilai {#comment:3}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Should be fixed now in rpm.org HEAD, all access mode tests are now done
+using O\_ACCMODE masks (unless of course I missed some spot :)

--- a/ticket/51.md
+++ b/ticket/51.md
@@ -1,0 +1,44 @@
+---
+lang: en
+title: '\#51 (Fix ordering algorithm) - rpm - Trac'
+---
+
+Ticket \#51 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Fix ordering algorithm
+----------------------
+
+  -------------- -------------- -------------- -----------------
+  Reported by:   FlorianFesti   Assigned to:   FlorianFesti
+  Priority:      major          Milestone:     rpm-4.8.0
+  Component:     rpm            Version:       RPM Development
+  Keywords:      ordering       Cc:            
+                                               
+  -------------- -------------- -------------- -----------------
+
+### Description {#comment:description}
+
+The current ordering algorithm does not collect all members of a
+dependency cycle before proceeding with packages requiring the cycle.
+This can lead to scriptlets failing for not yet installed dependencies.
+
+Change History
+--------------
+
+### 04/15/09 11:22:36 changed by FlorianFesti {#comment:1}
+
+-   **owner** changed from *pmatilai* to *FlorianFesti*.
+
+### 04/22/09 08:17:49 changed by FlorianFesti {#comment:2}
+
+-   **status** changed from *new* to *assigned*.
+
+### 06/19/09 07:32:40 changed by FlorianFesti {#comment:3}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.

--- a/ticket/52.md
+++ b/ticket/52.md
@@ -1,0 +1,53 @@
+---
+lang: en
+title: '\#52 (\[PATCH\] Add \--disable-dependency-tracking to %configure
+  options) - rpm - Trac'
+---
+
+Ticket \#52 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 4 years ago
+
+\[PATCH\] Add \--disable-dependency-tracking to %configure options
+------------------------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+autotools dependency tracking isn\'t generally useful in rpm builds;
+disabling it results in cleaner build logs and possibly slight build
+speedups.
+
+Attachments
+-----------
+
+[0003-Add-disable-dependency-tracking-to-configure-opti.patch](/attachment/ticket/52/0003-Add-disable-dependency-tracking-to-configure-opti.patch "View attachment") (0.8 kB) - added by *scop* on 04/19/09 20:56:46.
+:   Add \--disable-dependency-tracking to %configure options
+
+Change History
+--------------
+
+### 04/19/09 20:56:46 changed by scop
+
+-   **attachment**
+    *0003-Add-disable-dependency-tracking-to-configure-opti.patch*
+    added.
+
+Add \--disable-dependency-tracking to %configure options
+
+### 03/07/12 12:14:18 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Finally remembered to add this, sorry\... Thanks for the patch.

--- a/ticket/54.md
+++ b/ticket/54.md
@@ -1,0 +1,78 @@
+---
+lang: en
+title: '\#54 (RFE: use quilt for %patch management) - rpm - Trac'
+---
+
+Ticket \#54 (closed enhancement: fixed)
+=======================================
+
+Opened 7 years ago
+
+Last modified 4 years ago
+
+RFE: use quilt for %patch management
+------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   ensc    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     rpm-4.11.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+It would be nice when \'quilt\'
+([http://savannah.nongnu.org/projects/quilt](https://web.archive.org/web/20151226231506/http://savannah.nongnu.org/projects/quilt))
+is supported for managing the patchsets. When having packages with much
+patches, it is often difficulty to rediff them as multiple patches might
+affect one source file and the usual \'gendiff\' will fail then.
+
+\'quilt\' eases rediffing and generation of new patches very much (e.g.
+see its manpage).
+
+To use \'quilt\' a
+
+\| %patch1 -p 1 -b .foo
+
+has to be translated to
+
+\| quilt import -p 1 %PATCH1 && quilt push
+
+The \'-b \...\' is to be ignored. The conventional \'patch\' method must
+stay but there should be a way to switch to \'quilt\'.
+
+Change History
+--------------
+
+### 06/05/09 09:47:18 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *assigned*.
+
+Yup, the traditional %patch approach is getting a bit old and tired.
+Mandriva actually has patches to do something like this with git, and I
+see no reason why the approach couldn\'t be integrated a bit tighter and
+generalized to work with quilt, hg, bzr and such (to let each developer
+use what they\'re most familiar with). Also related to ticket
+[\#13](13 "RFE: Having macro `%patches' would be good for aplying a list of patches.  ... (new)").
+
+### 06/25/12 08:04:48 changed by pmatilai {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.11.0*.
+
+There\'s now an rough initial implementation in rpm.org master with some
+new macros:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=6c5214950e5885c33c498969ca256c9550f5936b](https://web.archive.org/web/20151226231506/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=6c5214950e5885c33c498969ca256c9550f5936b)
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=5322c3bd4bb99e9f1221eeddaf8de4da0f729e99](https://web.archive.org/web/20151226231506/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=5322c3bd4bb99e9f1221eeddaf8de4da0f729e99)
+
+I\'m suspect things will change somewhat (eg %autosetup should probably
+default to applying all the patches instead of requiring an option to do
+it) but its usable for early testing and the macros should work with any
+rpm \>= 4.6.0 version. As it is, basically replace \"%setup\" with
+\"%autosetup -A -S \<scm\>\" (regular %setup options accepted as well,
+replace \<scm\> with git, hg, bzr or quilt and add eg -p1 if you need)
+to have the expanded sources and patch applications to be brought under
+version control.

--- a/ticket/56.md
+++ b/ticket/56.md
@@ -1,0 +1,178 @@
+---
+lang: en
+title: '\#56 (RFE: Handle \''\~\'' in version/release to lower priority in
+  rpmVersionCompare()) - rpm - Trac'
+---
+
+Ticket \#56 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 3 years ago
+
+RFE: Handle \'\~\' in version/release to lower priority in rpmVersionCompare()
+------------------------------------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   ensc    Assigned to:   pmatilai
+  Priority:      major   Milestone:     rpm-4.10.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            stick, stressy
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+It would be nice when a special handling of \'\~\' would be introduced
+to mark \"negative\" version tokens. E.g. so that
+
+\| foo-1.0\~beta \< foo-1.0
+
+holds. This would simplify complicated rulesets which deal with such
+naming schemes by abusing %release for it.
+
+Attachments
+-----------
+
+[rpm-tilde-support.diff](/attachment/ticket/56/rpm-tilde-support.diff "View attachment") (1.7 kB) - added by *jengelh* on 11/09/09 14:52:46.
+:   4.7 rpm tilde patch for vercmp
+
+[rpmbuild-tilde-support.diff](/attachment/ticket/56/rpmbuild-tilde-support.diff "View attachment") (1.1 kB) - added by *jengelh* on 11/09/09 14:53:04.
+:   4.7 patch for rpmbuild
+
+[0001.diff](/attachment/ticket/56/0001.diff "View attachment") (1.7 kB) - added by *jengelh* on 07/27/10 11:28:54.
+:   patch for rpm-4.8
+
+[0002.diff](/attachment/ticket/56/0002.diff "View attachment") (1.1 kB) - added by *jengelh* on 07/27/10 11:29:10.
+:   patch for rpmbuild-4.8
+
+Change History
+--------------
+
+### 09/18/09 12:19:26 changed by stick {#comment:1}
+
+-   **cc** set to *stick*.
+
+### 09/25/09 09:21:00 changed by jengelh {#comment:2}
+
+Also pullable via
+
+> [git://dev.medozas.de/rpm](https://web.archive.org/web/20150920141457/git://dev.medozas.de/rpm)
+> master
+
+### 11/09/09 14:16:03 changed by jengelh {#comment:3}
+
+The patch 0001.diff was actually for 4.4.2, because someone had the
+bright idea of making the master branch 4.4.2 instead of 4.7. Adding new
+ones.
+
+### 11/09/09 14:52:46 changed by jengelh {#changed-by-jengelh}
+
+-   **attachment** *rpm-tilde-support.diff* added.
+
+4.7 rpm tilde patch for vercmp
+
+### 11/09/09 14:53:04 changed by jengelh {#changed-by-jengelh-1}
+
+-   **attachment** *rpmbuild-tilde-support.diff* added.
+
+4.7 patch for rpmbuild
+
+### 07/27/10 11:28:54 changed by jengelh {#changed-by-jengelh-2}
+
+-   **attachment** *0001.diff* added.
+
+patch for rpm-4.8
+
+### 07/27/10 11:29:10 changed by jengelh {#changed-by-jengelh-3}
+
+-   **attachment** *0002.diff* added.
+
+patch for rpmbuild-4.8
+
+### 07/27/10 11:29:30 changed by jengelh {#comment:4}
+
+git location rebased.
+
+### 09/02/10 19:18:32 changed by stressy {#comment:5}
+
+-   **cc** changed from *stick* to *stick, stressy*.
+
+### 11/22/10 10:47:28 changed by pmatilai {#comment:6}
+
+I finally (duh) got around to take a closer look at this, starting with
+a test-suite for the vercmp() behavior to make it easier to test and
+spot regressions.
+
+For the simple case of eg 6.0 vs 6.0\~rc1 it seems to work as intended,
+eg
+
+     16: rpmvercmp(6.0~rc1, 6.0) = -1                    ok
+     17: rpmvercmp(6.0~rc1, 6.0~rc1) = 0                 ok
+
+but it doesn\'t handle multiple tildes correctly, these can\'t both be
+right:
+
+     18: rpmvercmp(6.0~rc1~git123, 6.0~rc1) = -1         ok
+     19: rpmvercmp(6.0~rc1, 6.0~rc1~git123) = -1         ok
+
+Since mirroring dpkg behavior seems the sensible thing to do here,
+6.0\~rc1 should be considered newer than 6.0\~rc1\~git123 afaict.
+
+Another thing that needs considering is handling compatibility, this
+introduces a rather big change in rpm behavior. While recent rpm
+versions reject tilde in version and release at build-time, there\'s a
+huge installed base where that\'s not the case, and packages built with
+those versions can have tilde in version/release and expecting a
+completely different behavior.
+
+It would be possible to add an rpmlib() dependency tracking for new
+packages using the tilde syntax, that would prevent old rpm versions
+from installing packages depending on the new semantics. However that
+still leaves the problem of new rpm installing older packages which can
+have tilde in version/release without meaning the new semantics. Fully
+handling it would require rpmvercmp() taking a flag which semantics to
+use\... which starts getting rather ugly.
+
+### 11/22/10 15:03:44 changed by james {#comment:7}
+
+> It would be possible to add an rpmlib() dependency tracking for new
+> packages using the tilde syntax, that would prevent old rpm versions
+> from installing packages depending on the new semantics
+
+This kind of solves the problem for rpm, although it seems pretty heavy
+handed for just a change to the version comparison. But for anything
+above rpm it doesn\'t help at all \... yum can\'t see those rpmlib when
+it sees a version in primary or updateinfo or etc.
+
+> However that still leaves the problem of new rpm installing older
+> packages which can have tilde in version/release without meaning the
+> new semantics. Fully handling it would require rpmvercmp() taking a
+> flag which semantics to use
+
+Well, in theory you\'d need two flags (one for each side of the test).
+But if you did that then \_everything\_ that produced or consumed an
+rpmversion would have to also produce/consume a flag. IMNSHO this isn\'t
+going to happen.
+
+If you are worried that there are significant rpms out there with \~ in
+them, a much better fix is to just do the proposed \~ change but wait a
+few years with the current \"\~ is invalid\" code in rpmbuild still on.
+Or just don\'t change it :). No rpmlib and no flags, please.
+
+### 11/23/10 12:18:01 changed by jengelh {#comment:8}
+
+rpmbuild \--allow-tilde :-) And later remove it again.
+
+### 04/23/12 09:39:57 changed by pmatilai {#comment:9}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+This is now included, finally :)
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=db28221a4a48f6ee3c804c92314330637c808638](https://web.archive.org/web/20150920141457/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=db28221a4a48f6ee3c804c92314330637c808638)
+
+### 04/23/12 09:40:11 changed by pmatilai {#comment:10}
+
+-   **milestone** set to *rpm-4.10.0*.

--- a/ticket/59.md
+++ b/ticket/59.md
@@ -1,0 +1,69 @@
+---
+lang: en
+title: '\#59 (Disallow comparison operators in NVR, split w/o whitespace
+  when parsing specfile) - rpm - Trac'
+---
+
+Ticket \#59 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Disallow comparison operators in NVR, split w/o whitespace when parsing specfile
+--------------------------------------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   jnovy
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+rpm currently allows comparison operator chars (\<, \>, =) in Name,
+Version and Release, and also requires whitespace around them in
+specfiles.
+
+I think here\'s room for two improvements:
+
+-   Disallow use of \<, \>, and = in Name, Version and Release
+-   Do not require whitespace around these in specfiles (so that e.g.
+    Requires: foo\>=1 would be expanded to mean to require version 1 or
+    higher of foo, instead of something named \"foo\>=1\").
+
+See for example
+[http://rpmlint.zarb.org/cgi-bin/trac.cgi/ticket/174](https://web.archive.org/web/20150920084434/http://rpmlint.zarb.org/cgi-bin/trac.cgi/ticket/174)
+and the linked bug reports for examples of problems the current behavior
+causes.
+
+Change History
+--------------
+
+### 06/05/09 08:36:18 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *pmatilai* to *jnovy*.
+
+No disagreement at least wrt disallowing \<\> and various other weird
+characters that might get interpreted by the shell, these have security
+implications too (see
+[RhBug:493157](https://web.archive.org/web/20150920084434/https://bugzilla.redhat.com/show_bug.cgi?id=493157 "493157 in RhBug")).
+And over to Jindrich :)
+
+### 06/10/09 13:12:56 changed by jnovy {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+The first point makes perfectly sense. There shouldn\'t be any of
+\'\<\', \'=\', \'\>\' as a part of NVR and rpmbuild should complain
+about it. This part is now fixed.
+
+On the other hand the space before the relation makes sense wrt spec
+readability so I\'d remain it as is.
+
+The current behaviour is that if one from \"\<=\>\" is present in the N,
+V or R then rpmbuild will fail.

--- a/ticket/63.md
+++ b/ticket/63.md
@@ -1,0 +1,47 @@
+---
+lang: en
+title: '\#63 (Add -h to rpm2cpio) - rpm - Trac'
+---
+
+Ticket \#63 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Add -h to rpm2cpio
+------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+rpm2cpio command does not accept -h parameter to print user some help.
+Attached patch fixes it.
+
+Attachments
+-----------
+
+[13-rpm2cpio-help.diff](/attachment/ticket/63/13-rpm2cpio-help.diff "View attachment")
+(0.7 kB) - added by *nijel* on 06/10/09 07:05:47.
+
+Change History
+--------------
+
+### 06/10/09 07:05:47 changed by nijel
+
+-   **attachment** *13-rpm2cpio-help.diff* added.
+
+### 06/18/09 11:56:22 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied, thanks for the patch.

--- a/ticket/65.md
+++ b/ticket/65.md
@@ -1,0 +1,56 @@
+---
+lang: en
+title: '\#65 (Out of source build fails because of gentagtbl.sh) - rpm -
+  Trac'
+---
+
+Ticket \#65 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Out of source build fails because of gentagtbl.sh
+-------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+There is not path to gentagtbl.sh in Makefile.am and out of source build
+fails because of this. Attached patch fixes it.
+
+Attachments
+-----------
+
+[60\_fix-out-build.patch](/attachment/ticket/65/60_fix-out-build.patch "View attachment")
+(479 bytes) - added by *nijel* on 06/10/09 07:09:16.
+
+Change History
+--------------
+
+### 06/10/09 07:09:16 changed by nijel
+
+-   **attachment** *60\_fix-out-build.patch* added.
+
+### 06/12/09 06:07:47 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+The patch misses handling of tagtbl.c include in lib/tagname.c which
+causes the out of source build fail too. Fixed now in HEAD, thanks for
+the patch + reporting.
+
+### 06/17/09 12:17:30 changed by nijel {#comment:2}
+
+Ah, I forgot that I \"fixed\" it by adding -I. to CPPFLAGS (which I have
+to set anyway because of
+[\#61](61 "Configure does not find nss and nspr (closed)")).

--- a/ticket/69.md
+++ b/ticket/69.md
@@ -1,0 +1,55 @@
+---
+lang: en
+title: '\#69 (RFE, PATCH: Allow -d with %patch) - rpm - Trac'
+---
+
+Ticket \#69 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+RFE, PATCH: Allow -d with %patch
+--------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+It\'s annoying having to cd between dirs and when applying patches that
+are generated with their toplevel dir below the toplevel dir extracted
+from sources. The attached patch against current git (warning: compile
+tested only) allows using -d with %patch to \"fix\" this.
+
+Attachments
+-----------
+
+[0004-Add-d-option-to-patch.patch](/attachment/ticket/69/0004-Add-d-option-to-patch.patch "View attachment") (3.4 kB) - added by *scop* on 06/16/09 19:27:13.
+:   Add -d to %patch
+
+Change History
+--------------
+
+### 06/16/09 19:27:13 changed by scop
+
+-   **attachment** *0004-Add-d-option-to-patch.patch* added.
+
+Add -d to %patch
+
+### 08/14/09 08:42:36 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Seems to work\... Applied, thanks for the patch.
+
+Although all these %patch options make me want to just let it pass any
+unknown stuff down to the actual patch command without trying to
+validate but \... that\'s another story.

--- a/ticket/70.md
+++ b/ticket/70.md
@@ -1,0 +1,61 @@
+---
+lang: en
+title: '\#70 (RFE: Allow multiple -f options to %files) - rpm - Trac'
+---
+
+Ticket \#70 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+RFE: Allow multiple -f options to %files
+----------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   jnovy
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Currently, at least with rpm 4.6.1, multiple -f options to %files does
+not work as expected; the last one given trumps all previous ones.
+Making it possible to specify multiple -f\'s would get rid of the
+annoyance where one has to fiddle with concatenating all generated file
+lists into one.
+
+Dummy test case specfile attached.
+
+Attachments
+-----------
+
+[foo.spec](/attachment/ticket/70/foo.spec "View attachment") (0.6 kB) - added by *scop* on 06/16/09 19:34:12.
+:   Test specfile
+
+Change History
+--------------
+
+### 06/16/09 19:34:12 changed by scop
+
+-   **attachment** *foo.spec* added.
+
+Test specfile
+
+### 06/18/09 11:25:03 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *pmatilai* to *jnovy*.
+
+Yup, known thing (also reported as
+[RhBug:475359](https://web.archive.org/web/20150920142652/https://bugzilla.redhat.com/show_bug.cgi?id=475359 "475359 in RhBug")).
+
+### 06/23/09 09:10:17 changed by jnovy {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Feature is now implemented in upstream. Thanks for a spec for testing.

--- a/ticket/72.md
+++ b/ticket/72.md
@@ -1,0 +1,50 @@
+---
+lang: en
+title: '\#72 (Few typos in javadeps) - rpm - Trac'
+---
+
+Ticket \#72 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Few typos in javadeps
+---------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   nijel     Assigned to:   pmatilai
+  Priority:      trivial   Milestone:     
+  Component:     rpm       Version:       RPM Development
+  Keywords:                Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+Javadeps programs seems to contain some typos:
+
+X: rpm: spelling-error-in-binary ./usr/lib/rpm/javadeps preceeded
+preceded X: rpm: spelling-error-in-binary ./usr/lib/rpm/javadeps
+specifing specifying X: rpm: spelling-error-in-binary
+./usr/lib/rpm/javadeps capabilites capabilities
+
+Change History
+--------------
+
+### 06/22/09 13:00:10 changed by nijel {#comment:1}
+
+Oops, forgot to format it properly:
+
+    X: rpm: spelling-error-in-binary ./usr/lib/rpm/javadeps preceeded preceded
+    X: rpm: spelling-error-in-binary ./usr/lib/rpm/javadeps specifing specifying
+    X: rpm: spelling-error-in-binary ./usr/lib/rpm/javadeps capabilites capabilities
+
+### 06/23/09 06:59:01 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Heh, I wonder if anything actually uses the javadeps thing, certainly
+these aren\'t \"user visible\" for real. Fixed anyway, thanks :)

--- a/ticket/77.md
+++ b/ticket/77.md
@@ -1,0 +1,43 @@
+---
+lang: en
+title: '\#77 (Redundant po/rpmpopt.pot file causing problems) - rpm -
+  Trac'
+---
+
+Ticket \#77 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Redundant po/rpmpopt.pot file causing problems
+----------------------------------------------
+
+  -------------- ------- -------------- ----------
+  Reported by:   raven   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       
+  Keywords:              Cc:            raven
+                                        
+  -------------- ------- -------------- ----------
+
+### Description {#comment:description}
+
+This additional POT file is causing some problems, like confusing
+Transifex \[1\]. Tx apparently thinks that this is the proper POT file.
+Please remove it from every active branch (master, 4.6.x, and 4.7.x), if
+it\'s possible.
+
+\[1\]
+[https://translate.fedoraproject.org/projects/rpm/master](https://web.archive.org/web/20150921031156/https://translate.fedoraproject.org/projects/rpm/master)
+
+Change History
+--------------
+
+### 11/23/09 13:22:26 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Okay removed from all current branches, finally\...

--- a/ticket/78.md
+++ b/ticket/78.md
@@ -1,0 +1,60 @@
+---
+lang: en
+title: '\#78 (Allow noarch package to have architecture specific
+  subpackages) - rpm - Trac'
+---
+
+Ticket \#78 (new enhancement)
+=============================
+
+Opened 6 years ago
+
+Last modified 3 years ago
+
+Allow noarch package to have architecture specific subpackages
+--------------------------------------------------------------
+
+  -------------- -------- -------------- -----------------
+  Reported by:   msivak   Assigned to:   pmatilai
+  Priority:      major    Milestone:     
+  Component:     rpm      Version:       RPM Development
+  Keywords:               Cc:            
+                                         
+  -------------- -------- -------------- -----------------
+
+### Description {#comment:description}
+
+The reason for this request is simple. Scripting languages are mostly
+architecture independent, but we sometimes have a special module that
+has to be excluded from some archs.
+
+The module itself is architecture independent, but it can utilize
+component that is not present on some architectures (like grub on s390).
+And we need to drop that dependency for the architecture in question.
+
+But at the moment, the ifnarch and [ExcludeArch?](/ExcludeArch) tags do
+not work with noarch packages and we can\'t change the subpackage to be
+architecture specific since the main package is tagged as noarch.
+
+Spliting the package in two would be a possible workaround, but it
+wouldn\'t reflect the logic of dependencies. The subpackage is only
+usable for the main package with corresponding version and moreover, the
+subpackage is architecture independent and only the dependencies are
+not.
+
+Change History
+--------------
+
+### 01/20/10 16:14:52 changed by opoplawski {#comment:1}
+
+Similar need for some Java packages that have JNI or some external C
+dependencies in subpackages.
+
+### 09/03/12 16:06:11 changed by vo.x {#comment:2}
+
+This would be very useful for [RubyGems?](/RubyGems).
+[RubyGems?](/RubyGems) package is platform independent, however, it
+needs to create folder structure for arch dependent gems. This directory
+layout should go into platform dependent -filesystem subpackage.
+Unfortunately, it is not possible without this feature. Thank you for
+considering this RFE.

--- a/ticket/806.md
+++ b/ticket/806.md
@@ -1,0 +1,77 @@
+---
+lang: en
+title: '\#806 (Fix self-obsoletes and self-conflicts behavior) - rpm -
+  Trac'
+---
+
+Ticket \#806 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 8 months ago
+
+Fix self-obsoletes and self-conflicts behavior
+----------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   pmatilai   Assigned to:   RpmTickets
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description (Last modified by pmatilai) {#comment:description}
+
+This doesn\'t seem particularly meaningful behavior (self-obsoleting
+package):
+
+    [root@dhcp102 noarch]# rpm -Uvh self-obsoletes-1.0-1.noarch.rpm 
+    Preparing...                ########################################### [100%]
+       1:self-obsoletes         ########################################### [100%]
+    [root@dhcp102 noarch]# rpm -Uvh self-obsoletes-1.0-1.noarch.rpm 
+    error: Failed dependencies:
+        self-obsoletes is obsoleted by (installed) self-obsoletes-1.0-1.noarch
+    [root@dhcp102 noarch]# 
+
+..and neither is this (self-conflict on name or provide):
+
+    [root@dhcp102 noarch]# rpm -Uvh self-conflict-1.0-1.noarch.rpm 
+    error: Failed dependencies:
+        self-conflict conflicts with self-conflict-1.0-1.noarch
+
+At least for the self-conflict case, there\'s even a potentially
+use-case for a \"singleton\" type packages:
+[http://lists.rpm.org/pipermail/rpm-maint/2010-April/002719.html](https://web.archive.org/web/20151210102428/http://lists.rpm.org/pipermail/rpm-maint/2010-April/002719.html)
+
+Change History
+--------------
+
+### 11/24/10 09:28:55 changed by pmatilai {#comment:1}
+
+-   **description** changed.
+
+### 11/24/10 15:49:55 changed by FlorianFesti {#comment:2}
+
+Self obsoletes could just silently remove the package from the
+transaction again. Packages added as erases by this package (as updated
+or obsoleted) should stay in the transaction. That way it would be
+possible to issue an update that removes a package from the system
+without installing something else.
+
+While it is possible to obsolete a package from another package for a)
+the package got renames or b) is now part of another package it is not
+possible to remove a package that is no longer necessary if there is no
+other package taking care of that. An example could be a
+driver/bugfix/workaround for a special hardware. Even if a later kernel
+fixes the problem the kernel package might not obsolete the package -
+may be because the distribution doesn\'t care or know.
+
+### 04/24/15 09:17:01 changed by FlorianFesti {#comment:3}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+This should be fixed as multiple improvement where done to both the
+conflict and the obsolete handling code.

--- a/ticket/81.md
+++ b/ticket/81.md
@@ -1,0 +1,60 @@
+---
+lang: en
+title: '\#81 (Call %clean by default) - rpm - Trac'
+---
+
+Ticket \#81 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 5 years ago
+
+Call %clean by default
+----------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   spot    Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Currently, in Fedora, we require all packages to have this in their spec
+file:
+
+%clean rm -rf %{buildroot}
+
+Really, this should just be a default within RPM. As Panu pointed out on
+the discussion thread at fedora-devel-list:
+
+\*\*\*\*\*
+
+Another, perhaps simpler alternative would be making rpm inject default
+%clean action when spec doesn\'t define one. To disable/customize the
+default behavior, you\'d just add an empty (or otherwise custom) %clean
+in the spec, no special disabler logic required.
+
+It is of course a change of behavior in rpm but allows getting rid of
+the %clean section in 99% of specs and permits backwards compatibility
+too: if you want to have %clean do (or not do) whatever you want, you
+just keep the %clean section in the spec. It\'d make those special cases
+stand out clearly too, all you have to do is grep for %clean.
+
+\*\*\*\*\*
+
+Please implement. :)
+
+Change History
+--------------
+
+### 08/17/09 08:36:38 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Done:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=3fc58248d23d6f720942e5cbf4f92db246a802f0](https://web.archive.org/web/20150920142709/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=3fc58248d23d6f720942e5cbf4f92db246a802f0)

--- a/ticket/82.md
+++ b/ticket/82.md
@@ -1,0 +1,51 @@
+---
+lang: en
+title: '\#82 (%sources macro gets expanded twice in case there is a
+  BuildArch entry present) - rpm - Trac'
+---
+
+Ticket \#82 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+%sources macro gets expanded twice in case there is a BuildArch entry present
+-----------------------------------------------------------------------------
+
+  -------------- ---------- -------------- -----------
+  Reported by:   belegdol   Assigned to:   pmatilai
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM 4.7.x
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------
+
+### Description {#comment:description}
+
+In case of the following spec file:\
+[http://belegdol.fedorapeople.org/sdlmame-data-samples.spec\[\[BR](https://web.archive.org/web/20150920122424/http://belegdol.fedorapeople.org/sdlmame-data-samples.spec%5B%5BBR)\]\]
+The %{sources} macro will get expanded twice, causing the build to
+fail:\
+[http://belegdol.fedorapeople.org/build-0133-1.fc12.log\[\[BR](https://web.archive.org/web/20150920122424/http://belegdol.fedorapeople.org/build-0133-1.fc12.log%5B%5BBR)\]\]
+It would be nice to have this fixed so that this new RPM 4.6 feature
+could be used to its full extent, especially that Fedora 9 is now EOL
+and all active branches support it.
+
+Change History
+--------------
+
+### 07/23/09 09:10:59 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *assigned*.
+
+### 08/17/09 09:17:36 changed by pmatilai {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed in HEAD now:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=d8cde273e5523364df4f4f9ae7ad3374cf02e549](https://web.archive.org/web/20150920122424/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=d8cde273e5523364df4f4f9ae7ad3374cf02e549)
+and will pull into 4.6.x and 4.7.x branches too when preparing next
+maintenance updates.

--- a/ticket/820.md
+++ b/ticket/820.md
@@ -1,0 +1,52 @@
+---
+lang: en
+title: '\#820 (Rpmdb should keep better track of its children) - rpm -
+  Trac'
+---
+
+Ticket \#820 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 4 years ago
+
+Rpmdb should keep better track of its children
+----------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   pmatilai   Assigned to:   RpmTickets
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+It\'s way too easy to create dangling iterators. Trivial reproducer in
+python
+
+    >>> import rpm
+    >>> ts = rpm.ts()
+    >>> mi = ts.dbMatch('name')
+    >>> ts.closeDB() # or del ts for that matter
+
+\...and poof, mi\'s locks can\'t be released without exiting the process
+(or calling rpmdbCheckTerminate() on C-side which ends up doing the
+same).
+
+Rpm should close + invalidate the iterators before closing the db itself
+to avoid creating these zombies.
+
+Change History
+--------------
+
+### 04/15/11 07:18:31 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+This was simpler than I thought: iterators take a refcount on the
+database so all that is needed is to use rpmdbClose() on iterator free
+instead of only decrementing refcount.

--- a/ticket/83.md
+++ b/ticket/83.md
@@ -1,0 +1,53 @@
+---
+lang: en
+title: '\#83 (Add macros which will make python packaging easier) - rpm
+  - Trac'
+---
+
+Ticket \#83 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 5 years ago
+
+Add macros which will make python packaging easier
+--------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   stick   Assigned to:   pmatilai
+  Priority:      major   Milestone:     rpm-4.8.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+Please add the following definitions (they\'re based on Fedora and will
+be used by openSUSE too) to rpm macros:
+
+`%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}`
+
+`%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(1)")}`
+
+`%{!?python_version: %global python_version %(%{__python} -c "import sys ; print sys.version[:3]")}`
+
+Change History
+--------------
+
+### 08/18/09 06:24:00 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Done:
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=3e5097c97541fa0b8f289ef3b6011bdc3b4dc002](https://web.archive.org/web/20150920090643/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=3e5097c97541fa0b8f289ef3b6011bdc3b4dc002)
+Note that construct that works in spec files doesn\'t work as is in
+macro files so what\'s added is slightly different.
+
+### 08/10/10 15:15:36 changed by wis3384 {#comment:2}
+
+> [htc evo
+> cases](https://web.archive.org/web/20150920090643/http://htcevo4gcase.com/)
+> Changed 1 year ago by admin

--- a/ticket/836.md
+++ b/ticket/836.md
@@ -1,0 +1,46 @@
+---
+lang: en
+title: '\#836 (%files removes DOCDIR) - rpm - Trac'
+---
+
+Ticket \#836 (closed defect: fixed)
+===================================
+
+Opened 5 years ago
+
+Last modified 4 years ago
+
+%files removes DOCDIR
+---------------------
+
+  -------------- --------- -------------- -----------------
+  Reported by:   hicham    Assigned to:   RpmTickets
+  Priority:      trivial   Milestone:     
+  Component:     rpm       Version:       RPM Development
+  Keywords:                Cc:            
+                                          
+  -------------- --------- -------------- -----------------
+
+### Description {#comment:description}
+
+If a package install docs to DOCDIR, they get removed in %files section
+by the %doc macro as you can see in
+[http://rpm.org/gitweb?p=rpm.git;a=blob;f=build/files.c;h=8d7fb2ed02459681386396a64bcb716e8bfe223e;hb=HEAD\#l944](https://web.archive.org/web/20150920083321/http://rpm.org/gitweb?p=rpm.git;a=blob;f=build/files.c;h=8d7fb2ed02459681386396a64bcb716e8bfe223e;hb=HEAD#l944)
+
+So in this case we have two solutions : - Don\'t use %doc to install
+COPYING [ChangeLog?](/ChangeLog) \... - Force the buildsystem to install
+docs somewhere else
+
+First option means nullifying the use of %doc, second would mean
+installing docs in a non-standard location.
+
+Change History
+--------------
+
+### 06/13/11 09:04:51 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Fixed upstream now (after far too much pondering for the silly thing):
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=2f6bfc99d01df941f6aaad8497150f82eeb75311](https://web.archive.org/web/20150920083321/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=2f6bfc99d01df941f6aaad8497150f82eeb75311)

--- a/ticket/84.md
+++ b/ticket/84.md
@@ -1,0 +1,53 @@
+---
+lang: en
+title: '\#84 (Add xz and lzma support to brp-compress) - rpm - Trac'
+---
+
+Ticket \#84 (closed enhancement: fixed)
+=======================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Add xz and lzma support to brp-compress
+---------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+The attached patch adds support for recompressing \*.xz and \*.lzma in
+brp-compress. I checked with xz upstream and he confirmed support for
+\*.lzma is going to stay in xz, so no need for lzma for decompressing
+those files.
+
+Attachments
+-----------
+
+[0006-Add-.xz-and-.lzma-recompress-support-to-brp-compre.patch](/attachment/ticket/84/0006-Add-.xz-and-.lzma-recompress-support-to-brp-compre.patch "View attachment") (1.3 kB) - added by *scop* on 08/03/09 21:37:43.
+:   Add xz and lzma recompress support to brp-compress
+
+Change History
+--------------
+
+### 08/03/09 21:37:43 changed by scop
+
+-   **attachment**
+    *0006-Add-.xz-and-.lzma-recompress-support-to-brp-compre.patch*
+    added.
+
+Add xz and lzma recompress support to brp-compress
+
+### 08/10/09 09:09:31 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Applied, thanks for the patch!

--- a/ticket/847.md
+++ b/ticket/847.md
@@ -1,0 +1,111 @@
+---
+lang: en
+title: '\#847 (RFE: ability to show scriptlet program arguments) - rpm -
+  Trac'
+---
+
+Ticket \#847 (closed enhancement: fixed)
+========================================
+
+Opened 4 years ago
+
+Last modified 3 years ago
+
+RFE: ability to show scriptlet program arguments
+------------------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   scop    Assigned to:   pmatilai
+  Priority:      minor   Milestone:     rpm-4.10.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+There does not seem to be any way to display scriptlet program
+arguments.
+
+For example, for `%post -p "/bin/echo hello"` I could not find any way
+to get the \"hello\" displayed or queried, only the /bin/echo part is
+shown.
+
+    $ rpm -qp --scripts foo-1.0-3.fc14.x86_64.rpm 
+    postinstall program: /bin/echo
+
+    $ rpm -qp --qf="%{POSTINPROG}\n" foo-1.0-3.fc14.x86_64.rpm 
+    /bin/echo
+
+    $ rpm -qp --qf="%{POSTINFLAGS}\n" foo-1.0-3.fc14.x86_64.rpm 
+    (none)
+
+Change History
+--------------
+
+### 09/12/11 06:00:54 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+-   **status** changed from *new* to *assigned*.
+
+The trick is that FOOPROG tags are actually arrays if more than one
+argument is present (see
+[http://rpm.org/gitweb?p=rpm.git;a=blob;f=build/parseScript.c;hb=HEAD](https://web.archive.org/web/20150920130113/http://rpm.org/gitweb?p=rpm.git;a=blob;f=build/parseScript.c;hb=HEAD)
+from line 326 onwards). You can use \--qf=\"\[%{POSTINPROG} \]\\n\" to
+get the other arguments.
+
+Thanks for pointing this out, there are a few places that should be
+updated to reflect the reality: \--scripts alias needs to use the array
+query format and VERIFYSCRIPTPROG is missing completely from the output.
+Will fix. Also the tag types in rpmtag.h probably need changing from
+\"s\" to \"s\[\]\", although I need to verify it doesn\'t break anything
+else (the tag types are supposedly static but there are a few exceptions
+like this where things get a bit funny).
+
+### (follow-up: [[↓ 3]{.small}](#comment:3) ) 09/12/11 09:40:07 changed by pmatilai {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+
+Okay, fixed in HEAD, \--scripts query now also shows all scriptlet
+interpreter arguments if present:
+
+    [pmatilai@localhost ~]$ rpm -qp --scripts /home/pmatilai/rpmbuild/RPMS/x86_64/argtest-1.0-4.x86_64.rpm
+    preinstall program: /bin/echo -a -c -e
+    postinstall scriptlet (using /bin/sh -x):
+    echo "echo this"
+    preuninstall scriptlet (using /bin/bash --posix --version -l -v -x):
+    echo "echo that"
+    postuninstall scriptlet (using /bin/sh):
+    echo "postun, nuting special"
+    posttrans scriptlet (using /usr/bin/python):
+    print "foo"
+    verify program: /sbin/ldconfig -x -y
+    [pmatilai@localhost ~]$
+
+While at it, some related bugs also fixed: accessing the fooprog tags
+are now defined as array types, meaning eg python accessing them will
+return the full array instead of just the first item. In addition,
+%verifyscript interpreter wasn\'t shown at all, and attempting to pass
+arguments to trigger scriptlet interpreters now fails at build-time
+(previously they were just silently discarded).
+
+BTW if rpmlint examines the fooprog tags, it\'ll need to be adjusted to
+expect arrays whereas it previously just got single strings (and for
+compatibility, it probably should handle both cases the best it can)
+
+### (in reply to: [[↑ 2]{.small}](#comment:2) ) 09/13/11 18:17:36 changed by scop {#comment:3}
+
+Replying to [pmatilai](847#comment:2 "Comment 2 for ticket:847"):
+
+> BTW if rpmlint examines the fooprog tags, it\'ll need to be adjusted
+> to expect arrays whereas it previously just got single strings (and
+> for compatibility, it probably should handle both cases the best it
+> can)
+
+Thanks, hopefully done sufficiently in
+[http://rpmlint.zarb.org/cgi-bin/trac.cgi/changeset/1885](https://web.archive.org/web/20150920130113/http://rpmlint.zarb.org/cgi-bin/trac.cgi/changeset/1885)
+
+### 05/28/12 16:12:56 changed by pmatilai {#comment:4}
+
+-   **milestone** set to *rpm-4.10.0*.

--- a/ticket/851.md
+++ b/ticket/851.md
@@ -1,0 +1,49 @@
+---
+lang: en
+title: '\#851 (results of \"make check\" tests depend on the packages
+  installed) - rpm - Trac'
+---
+
+Ticket \#851 (closed defect: fixed)
+===================================
+
+Opened 4 years ago
+
+Last modified 4 years ago
+
+results of \"make check\" tests depend on the packages installed
+----------------------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   akozumpl   Assigned to:   akozumpl
+  Priority:      major      Milestone:     
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+Running \'make check\' from tests/ when fakechroot is not available
+produces many failed tests instead of informing that the testing
+framework is incomplete.
+
+Similarly, if rpm is build on a system wihtout xz-devel, some tests are
+failing with even stranger errors (bad cpio header).
+
+A possible solution is make \"make check\" fail immediately with an
+explanation if either of those conditions are detected.
+
+Change History
+--------------
+
+### 11/16/11 08:38:30 changed by akozumpl {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+This has been fixed on the master branch by commits
+[f0d7459e51c93f89c014eff9d20cf81fccdbf1c3](https://github.com/rpm-software-management/rpm/commit/f0d7459e51c93f89c014eff9d20cf81fccdbf1c3 "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.")
+(the XZ dependency) and
+[f6baacaa07bc1069309c0afbf1369ea664c59742](https://github.com/rpm-software-management/rpm/commit/f6baacaa07bc1069309c0afbf1369ea664c59742 "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.")
+(the fakechroot dependency).

--- a/ticket/858.md
+++ b/ticket/858.md
@@ -1,0 +1,97 @@
+---
+lang: en
+title: '\#858 (%doc macro no longer handles files with spaces in their
+  names using \\ to quote.) - rpm - Trac'
+---
+
+Ticket \#858 (closed defect: fixed)
+===================================
+
+Opened 3 years ago
+
+Last modified 3 years ago
+
+%doc macro no longer handles files with spaces in their names using \\ to quote.
+--------------------------------------------------------------------------------
+
+  -------------- ------------ -------------- -----------------
+  Reported by:   opoplawski   Assigned to:   pmatilai
+  Priority:      major        Milestone:     rpm-4.11.0
+  Component:     rpm          Version:       RPM Development
+  Keywords:                   Cc:            
+                                             
+  -------------- ------------ -------------- -----------------
+
+### Description {#comment:description}
+
+With rpm 4.11.0-0.beta1.1.fc19:
+
+    %doc doc/Users\ guide\ Apache.html
+
+Gets executed as:
+
+    + cp -pr 'doc/Users /builddir/build/BUILDROOT/rubygem-passenger-3.0.19-1.fc19.i386/usr/share/doc/mod_passenger-3.0.19'
+    cp: missing destination file operand after 'doc/Users /builddir/build/BUILDROOT/rubygem-passenger-3.0.19-1.fc19.i386/usr/share/doc/mod_passenger-3.0.19'
+
+Using:
+
+    %doc 'doc/Users guide Apache.html'
+
+doesn\'t work either:
+
+    + cp -pr 'doc/Users $DOCDIR
+    cp -pr guide $DOCDIR
+    cp -pr Apache.html' /builddir/build/BUILDROOT/rubygem-passenger-3.0.19-1.fc19.x86_64/usr/share/doc/mod_passenger-3.0.19
+    cp: cannot stat 'doc/Users $DOCDIR\ncp -pr guide $DOCDIR\ncp -pr Apache.html': No such file or directory
+
+Change History
+--------------
+
+### 01/21/13 15:33:42 changed by pmatilai {#comment:1}
+
+-   **owner** changed from *RpmTickets* to *pmatilai*.
+
+Hmph\... this is quite an ugly mess.
+
+Single-quotation and backslash-escaping only ever \"worked\" in %doc by
+happenstance, they aren\'t \*supposed\* to work, and do not work in
+%files. What makes it so ugly is that the \"official\" way of
+double-quoting has (AFAICT) never worked for special %doc files in
+existing rpm versions, so people have been forced to look for \"whatever
+works\" alternatives.
+
+What I will do anyway is make double-quotation work for the special %doc
+(and %license) directives, to make the %files list behavior consistent.
+
+What to do with the rest is a bigger question mark: while its possible
+to revert back to mostly \"traditional\" behavior for %doc, that would
+open up the possibilities for nasty hacks (like passing arguments to
+\"cp\") again. I\'d rather not go there. Another possibility would be
+allowing single-quotation and backslash-escaping everywhere in %files,
+but that has a bigger chance of breaking something else in turn and not
+something I\'d want to do right before a stable release.
+
+I\'m tempted to just fix the double-quotation and tell people to use
+globs (the other \"official\" method) to workaround spaces in filenames
+for %doc if compatibility across different versions of rpm is needed,
+but maybe I\'d better sleep on it a bit.
+
+### 01/21/13 15:33:56 changed by pmatilai {#comment:2}
+
+-   **status** changed from *new* to *assigned*.
+
+### 01/21/13 18:10:24 changed by opoplawski {#comment:3}
+
+I\'m happy with just about anything that would work. For me using ?
+instead of \"\\ \" does the trick.
+
+### 01/29/13 09:31:01 changed by pmatilai {#comment:4}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.11.0*.
+
+Okay, considering this fixed then: rpm \>= 4.11 only accepts
+double-quoting and globbing for %doc (and %license), and rpm \>= 4.10.3
+adds support for double-quoting (while remaining compatible with the old
+hacks). Interoperability with older versions can be achieved with globs.

--- a/ticket/872.md
+++ b/ticket/872.md
@@ -1,0 +1,98 @@
+---
+lang: en
+title: '\#872 (Verify shows change when duplicate UID used) - rpm -
+  Trac'
+---
+
+Ticket \#872 (closed defect: fixed)
+===================================
+
+Opened 2 years ago
+
+Last modified 1 year ago
+
+Verify shows change when duplicate UID used
+-------------------------------------------
+
+  -------------- -------- -------------- -----------------
+  Reported by:   archie   Assigned to:   RpmTickets
+  Priority:      minor    Milestone:     rpm-4.12.0
+  Component:     rpm      Version:       RPM Development
+  Keywords:               Cc:            
+                                         
+  -------------- -------- -------------- -----------------
+
+### Description {#comment:description}
+
+On a system where:
+
+-   Two different usernames \'aaa\' and \'bbb\' are associated with the
+    same UID 1234
+-   A package is installed with a file \'foo\' owned by user \'aaa\' in
+    the package manifest
+
+Then rpm -V will (sometimes?) incorrectly report a changed user for
+\'foo\' from \'aaa\' to \'bbb\'.
+
+As we all know, file ownership in Linux is by UID, not username, so rpm
+is doing a reverse lookup from UID to username (probably using
+getpwnam(3)) and (perhaps by chance) getting the wrong answer (\'bbb\'
+instead of \'aaa\') and then reporting this as a change, when in fact
+there is no change.
+
+The rpm verify algorithm for user (and similarly group) ownership should
+instead be:
+
+1.  Determine the UID associated with the installed file
+2.  Lookup the username corresponding to that UID (using getpwuid(3)
+    etc)
+3.  Compare that with the username in the package manifest
+
+Change History
+--------------
+
+### 06/05/14 04:59:12 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *invalid*.
+
+If duplicate UIDs are present on the system then what getpwuid() returns
+is just as much by chance as with getpwnam(), there\'s no abolute right
+or wrong at that point.
+
+### 06/06/14 09:51:59 changed by pmatilai {#comment:2}
+
+-   **status** changed from *closed* to *reopened*.
+-   **resolution** deleted.
+
+Reopening as per
+[http://lists.rpm.org/pipermail/rpm-maint/2014-June/003700.html](https://web.archive.org/web/20150923231909/http://lists.rpm.org/pipermail/rpm-maint/2014-June/003700.html)
+
+### 06/06/14 10:01:42 changed by pmatilai {#comment:3}
+
+-   **status** changed from *reopened* to *closed*.
+-   **resolution** set to *fixed*.
+
+\...and close as fixed as per
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=348eea3a4151b1dbe6f9976ef50cd7ba3820fa79](https://web.archive.org/web/20150923231909/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=348eea3a4151b1dbe6f9976ef50cd7ba3820fa79)
+
+Whether the former behavior was downright incorrect is perhaps debatable
+- verification showing change when the actual entries did not change
+seems buggy but then duplicate uids/users can be considered inconsistent
+system state, calling for investigation. With the above commit rpm now
+warns about duplicates but passes the verification in these cases.
+
+### 06/06/14 14:02:43 changed by archie {#comment:4}
+
+Thanks.
+
+Just to correct the record, the original description of what the
+algorithm \"should be\" was wrong. It should have stated:
+
+1.  Determine the UID of the installed file
+2.  Determine the UID of the username that is supposed to own the file
+3.  Compare steps 1 and 2 for equality
+
+### 09/16/14 11:06:41 changed by pmatilai {#comment:5}
+
+-   **milestone** set to *rpm-4.12.0*.

--- a/ticket/88.md
+++ b/ticket/88.md
@@ -1,0 +1,50 @@
+---
+lang: en
+title: '\#88 (liblua not detected on Debian) - rpm - Trac'
+---
+
+Ticket \#88 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 4 years ago
+
+liblua not detected on Debian
+-----------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     rpm-4.10.0
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+On Debian, the lua library is named liblua5.1 and configure script does
+not it detect because of it.
+
+There is also pkg-config support in Lua, which might be used:
+
+    $ pkg-config --libs lua5.1
+    -llua5.1  
+
+Change History
+--------------
+
+### 08/13/09 07:54:56 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *assigned*.
+
+Nod, the configure checks should be made to use pkg-config where
+available, this includes at least lua and sqlite.
+
+### 03/28/11 09:57:00 changed by pmatilai {#comment:2}
+
+-   **status** changed from *assigned* to *closed*.
+-   **resolution** set to *fixed*.
+-   **milestone** set to *rpm-4.10.0*.
+
+Fixed in HEAD\... at long last.

--- a/ticket/89.md
+++ b/ticket/89.md
@@ -1,0 +1,87 @@
+---
+lang: en
+title: '\#89 (\[PATCH\] Consider packages that would build with
+  \--specfile) - rpm - Trac'
+---
+
+Ticket \#89 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 5 years ago
+
+\[PATCH\] Consider packages that would build with \--specfile
+-------------------------------------------------------------
+
+  -------------- ---------- -------------- -----------------
+  Reported by:   lkundrak   Assigned to:   pmatilai
+  Priority:      major      Milestone:     rpm-4.9.0
+  Component:     rpm        Version:       RPM Development
+  Keywords:                 Cc:            
+                                           
+  -------------- ---------- -------------- -----------------
+
+### Description {#comment:description}
+
+Currently \--specfile takes all package structures into account, even
+those which would not result in binary packages since they lack %files
+section. This typically causes trouble with packages that only build
+into subpackages, since the user has no way if finding out which
+packages would actually build.
+
+To retain compatibility in that case this adds the source package to the
+list, using \"src\" as an arch, which makes it distinguishable from the
+binary packages.
+
+Attachments
+-----------
+
+[0001-Consider-packages-that-would-build-with-specfile.patch](/attachment/ticket/89/0001-Consider-packages-that-would-build-with-specfile.patch "View attachment")
+(1.7 kB) - added by *lkundrak* on 08/19/09 16:40:59.
+
+Change History
+--------------
+
+### 08/19/09 16:40:59 changed by lkundrak
+
+-   **attachment**
+    *0001-Consider-packages-that-would-build-with-specfile.patch* added.
+
+### 08/26/09 16:15:52 changed by lkundrak {#comment:1}
+
+Ping?
+
+### 09/11/09 10:31:43 changed by lkundrak {#comment:2}
+
+-   **milestone** set to *rpm-4.8.0*.
+
+### 10/08/09 10:29:58 changed by lkundrak {#comment:3}
+
+Ping.
+
+/me feels like no one loves him :(
+
+### 03/24/10 08:32:41 changed by pmatilai {#comment:4}
+
+/me thinks the more useful approach would be adding a method (cli switch
+or such) to access things from the source header instead. That avoids
+changing the output and makes various new things possible, such as
+querying sources/patches from the header.
+
+### 10/06/10 06:15:36 changed by pmatilai {#comment:5}
+
+-   **milestone** changed from *rpm-4.8.0* to *rpm-4.9.0*.
+
+### 10/12/10 12:27:36 changed by pmatilai {#comment:6}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+I consider this fixed in HEAD now, although quite differently:
+
+-   %files section is not required in order to generate packages (with
+    no files in them) anymore
+-   there\'s a new \'rpmspec\' command line tool which allows querying
+    either source or binary headers from a spec, complete with target
+    overriding and query formatting.

--- a/ticket/91.md
+++ b/ticket/91.md
@@ -1,0 +1,48 @@
+---
+lang: en
+title: '\#91 (Build with Lua fails in out of tree build) - rpm - Trac'
+---
+
+Ticket \#91 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+Build with Lua fails in out of tree build
+-----------------------------------------
+
+  -------------- ------- -------------- -----------------
+  Reported by:   nijel   Assigned to:   pmatilai
+  Priority:      major   Milestone:     
+  Component:     rpm     Version:       RPM Development
+  Keywords:              Cc:            
+                                        
+  -------------- ------- -------------- -----------------
+
+### Description {#comment:description}
+
+There is just wrong include path, see attached patch.
+
+Attachments
+-----------
+
+[fix-luaext.patch](/attachment/ticket/91/fix-luaext.patch "View attachment")
+(406 bytes) - added by *nijel* on 09/01/09 09:29:51.
+
+Change History
+--------------
+
+### 09/01/09 09:29:51 changed by nijel
+
+-   **attachment** *fix-luaext.patch* added.
+
+### 11/20/09 10:12:42 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+This had actually been fixed in HEAD in May already (commit
+[03e36789b62010026f099e885546be005a62461a](https://github.com/rpm-software-management/rpm/commit/03e36789b62010026f099e885546be005a62461a "Unsupported version control system "svn". Check that the Python bindings for "svn" are correctly installed.")),
+just not in stable branches. Thanks for the patch anyway :)

--- a/ticket/99.md
+++ b/ticket/99.md
@@ -1,0 +1,43 @@
+---
+lang: en
+title: '\#99 (RPM gives an cpio error on unwritable files) - rpm - Trac'
+---
+
+Ticket \#99 (closed defect: fixed)
+==================================
+
+Opened 6 years ago
+
+Last modified 6 years ago
+
+RPM gives an cpio error on unwritable files
+-------------------------------------------
+
+  -------------- -------------- -------------- -----------------
+  Reported by:   FlorianFesti   Assigned to:   pmatilai
+  Priority:      minor          Milestone:     
+  Component:     rpm            Version:       RPM Development
+  Keywords:                     Cc:            
+                                               
+  -------------- -------------- -------------- -----------------
+
+### Description {#comment:description}
+
+It would be much nicer if RPM would detect unwritable directories or
+file system in advance and error out. Shouldn\'t be too expensive as we
+stat() everything anyway.
+
+Change History
+--------------
+
+### 11/20/09 14:05:04 changed by pmatilai {#comment:1}
+
+-   **status** changed from *new* to *closed*.
+-   **resolution** set to *fixed*.
+
+Done in
+[http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=5e26a8be7193a90612d800eadba46b417c1d4944](https://web.archive.org/web/20150920142713/http://rpm.org/gitweb?p=rpm.git;a=commitdiff;h=5e26a8be7193a90612d800eadba46b417c1d4944),
+by a simple hack of making read-only filesystems appear as full. Of
+course it could be extended to specifically complain about read-only fs
+but me thinks read-only == full is a reasonable and simple mapping with
+practically no extra code.


### PR DESCRIPTION
and their attachments from the Way Back Machine (https://web.archive.org/)
Clean up links, header and footer and turn them into markdown.

While the tickets seem to work fine (e.g. https://ffesti.github.io/rpm-web/ticket/101) the attachments seem to still have some issues.
The links in the release notes don't work in my local repository as they are pointing to rpm.org but they should work if the tickets are merged into the official rpm-web repo.