### PR TITLE
contribute: reword GitHub link

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -6,9 +6,8 @@ title: rpm.org - Contribute
 
 ### Source code
 
-Our source code is maintained in a
-[git repository](https://github.com/rpm-software-management/rpm) at
-[GitHub](https://github.com/):
+Our source code is maintained in a GitHub
+[git repository](https://github.com/rpm-software-management/rpm):
 
 `git clone https://github.com/rpm-software-management/rpm.git`
 


### PR DESCRIPTION
We don't need to link to the github.com homepage. Give users a single link to make it simpler to click through to the main RPM repository.