### PR TITLE
Add plan file howto to release guide

### DIFF
--- a/devel_doc/git-cherry-plan
+++ b/devel_doc/git-cherry-plan
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+PROGRAM=cherry-plan
+CONFIG=cherryPlan
+HEAD=$(git rev-parse --abbrev-ref HEAD)
+ABBREV=$(git rev-parse --short HEAD | tr -d '\n' | wc -c)
+DIR=$(git config --get $CONFIG.directory); DIR=${DIR:+$DIR/}
+PATTERN="^(cherry picked from commit \(.*\))\$"
+README="\
+# Commands:
+# pick <commit> = use commit
+# drop <commit> = remove commit, not suitable
+# noop <commit> = remove commit, already applied
+#      <commit> = remove commit, not decided yet
+#
+# These lines MUST NOT be re-ordered; they are executed from top to bottom.
+#
+# vim:syntax=gitrebase"
+
+usage() {
+    echo "\
+usage: git $PROGRAM <command> [<args>]
+
+Manage persistent rebase-like todo lists (\"plans\") to cherry-pick commits.
+
+Useful for crafting larger cherry-pick batches and collaborating on them, e.g.
+when preparing stable releases.
+
+This tool produces a standalone file equivalent of
+
+    git rebase -i HEAD <branch>
+
+with a few extras, see the instructions at the bottom of the file.
+
+Commands
+    make <branch> [<limit> [<file>]]
+                        create plan for current branch with commits on <branch>
+                        except those up to (and including) <limit>, save to
+                        <file>
+    pull <branch> [<file>]
+                        append new commits on <branch> to plan <file>
+    apply [<file>]      apply plan <file> to current branch
+    mark [<file>]       mark applied commits in plan <file>
+
+Argument defaults
+    <file>              <current-branch>.plan
+    <limit>             HEAD
+
+Configuration
+    $CONFIG.directory
+                        where to save default plan <file>s, default: \$PWD
+    $CONFIG.fromPatterns
+                        line-separated list of patterns to extract applied
+                        commit from commit message, default:
+                        $PATTERN
+"
+    exit 1
+}
+
+print_readme() {
+    local head=$(abbrev $(git rev-parse HEAD))
+    local branch=$(abbrev $(git rev-parse $2))
+    local range=$head..$branch
+    local count=$(git rev-list --count $range)
+    echo >> $1
+    echo "# Rebase $range onto $head ($count commands)" >> $1
+    echo "#" >> $1
+    echo "$README" >> $1
+}
+
+fail_exists() {
+    if [ -f $1 ]; then
+        echo "File $1 already exists" >&2
+        exit 1
+    fi
+}
+
+fail_missing() {
+    if [ ! -f $1 ]; then
+        echo "File $1 not found" >&2
+        exit 1
+    fi
+}
+
+get_hash() {
+    sed 's/^.\{5\}//' | cut -d' ' -f1
+}
+
+abbrev() {
+    echo $1 | cut -c -$ABBREV
+}
+
+get_applied() {
+    local log=$(git rev-list --pretty="format:%b" $1..)
+    local patterns=$(git config --get-all $CONFIG.fromPatterns)
+    [ -z "$patterns" ] && patterns=$PATTERN
+    echo "$patterns" | while IFS= read -r line; do
+        echo "$log" | sed -n "s/$line/\1/p"
+    done
+}
+
+get_last() {
+    sed '/^#/d; /^$/d' $1 | tail -1 | get_hash
+}
+
+get_branch() {
+    sed -n 's/^# Rebase .*\.\.\(.*\) onto .*$/\1/p' $1
+}
+
+mark() {
+    sed -i "s/^noop /     /" $1
+    get_applied $2 | while read line; do
+        sed -i "s/^.\{5\}\($(abbrev $line)\)/noop \1/" $1
+    done
+}
+
+log() {
+    git rev-list --reverse --no-commit-header --pretty="format:     %h %s" $1
+}
+
+CMD=$1; shift
+
+if [ "$CMD" == "make" ]; then
+    branch=$1
+    [ -z "$branch" ] && usage
+    limit=$2
+    file=${3:-$DIR$HEAD.plan}
+    fail_exists $file
+    [ -n "$DIR" ] && mkdir -p $DIR
+    log $limit..$branch > $file
+    mark $file $branch
+    print_readme $file $branch
+    echo $file
+
+elif [ "$CMD" == "pull" ]; then
+    branch=$1
+    [ -z "$branch" ] && usage
+    file=${2:-$DIR$HEAD.plan}
+    fail_missing $file
+    limit=$(get_last $file)
+    if [ -z $limit ]; then
+        > $file
+    else
+        sed -i "/^.\{5\}$limit/q" $file
+    fi
+    log $limit..$branch | tee -a $file
+    print_readme $file $branch
+
+elif [ "$CMD" == "apply" ]; then
+    file=${1:-$DIR$HEAD.plan}
+    fail_missing $file
+    grep '^pick ' $file | while read line; do
+        commit=$(echo "$line" | get_hash)
+        echo "Applying commit $commit"
+        git cherry-pick -x $commit >/dev/null || false
+    done || exit 1
+    echo "Plan applied successfully!"
+
+elif [ "$CMD" == "mark" ]; then
+    file=${1:-$DIR$HEAD.plan}
+    fail_missing $file
+    mark $file $(get_branch $file)
+
+else
+    usage
+fi

--- a/devel_doc/plan.vim
+++ b/devel_doc/plan.vim
@@ -1,0 +1,22 @@
+function! s:cycle()
+    let l:cmds = ['    ', 'drop', 'pick']
+    let l:line = getline('.')
+    let l:i = index(l:cmds, l:line[0:3])
+    if l:i < 0
+        return
+    endif
+    let l:next = l:cmds[(l:i + 1) % len(l:cmds)]
+    call setline('.', l:next . l:line[4:])
+endfunction
+
+function! s:gitshow()
+    let l:hash = split(getline('.')[5:], ' ')[0]
+    silent exec "!git show --color " . l:hash . " | less -cR" | redraw!
+endfunction
+
+function! s:initplan()
+    nmap <buffer> <silent> <C-A>    :call <sid>cycle()<CR>
+    nmap <buffer> <silent> <CR>     :call <sid>gitshow()<CR>
+endfunction
+
+autocmd BufNewFile,BufRead *.plan call <sid>initplan()

--- a/devel_doc/release_maintaince.md
+++ b/devel_doc/release_maintaince.md
@@ -19,30 +19,206 @@ from a branch, not master.
 
 When pulling fixes from git master to stable branches, always use -x to get the automatic cherry-pick commit marker. This way its easier to see which patches come from master, and which commit exactly. If a cherry-pick conflicts,
 see if it's resolvable with a suitable upstream commit and if not, when
-fixing manually change the "cherry-picked from" message into "Backported from
-commit hash" to mark the difference.
+fixing manually change the "(cherry picked from commit ...)" message into
+"Backported from commit ..." to mark the difference.
 
-## Selecting commits for cherry-picking (or backporting) for maintenance updates
+## Selecting commits
 
-For each fix or other change you consider cherry-picking, ask yourself:
+Crafting a stable release is inherently a manual process which starts by
+selecting suitable commits from the master branch to cherry-pick or backport
+into the respective stable branch.
+
+While you can do this directly in git, it is recommended that you first create
+a text file that lists all commits on the master branch since the last release
+and mark those that you intend to pick.  This approach allows you to:
+
+* Keep track of which commits you've reviewed so far
+
+* Ensure that commits are always picked in chronological order
+
+* Email the plan to the team to get feedback
+
+* Tweak the plan easily, without having to (re)do any conflict resolution
+
+* Use a shell script to automate the cherry-picking
+
+* Try out different variants of the plan to see which apply cleanly
+
+The rest of this section describes a workflow that involves such a text file,
+one per stable branch, and a helper script.
+
+### Installing the script
+
+[Download](git-cherry-plan) the script, make it executable and put it into your
+`$PATH`.
+
+To allow the script to detect already applied commits, run:
+
+```
+$ git config --add cherryPlan.indicators '^(cherry picked from commit \(.*\))$'
+$ git config --add cherryPlan.indicators '^Backported from commit \(.*\)$'
+```
+
+### Making a plan
+
+First, generate a plan for the stable branch (e.g. rpm-4.15.x):
+
+```
+$ git checkout <stable>
+$ git cherry-plan make master
+```
+
+This will create a file `<stable>.plan` in the current directory with a
+chronological list of commits on master since the branching point, in a format
+similar to that of `git rebase -i`, and mark with `noop` those that have been
+cherry-picked or backported already.
+
+To later pull new commits from master into the plan, use:
+
+```
+$ git cherry-plan pull master
+```
+
+For complete usage help, run:
+
+```
+$ git cherry-plan -h
+```
+
+### Editing a plan
+
+The next step is to go through the unmarked commits and mark those that you
+intend to include in the release with `pick`.  For each commit you review, ask
+yourself:
 
 * Does it change the ABI or API in an incompatible way?
 
-    Generally adding entirely new APIs is okay, any other change is not, except of course to fix behavior bugs.
+    Generally adding entirely new APIs is okay, any other change is not, except
+    of course to fix behavior bugs.
 
 * Does it affect package building in an incompatible way?
 
-    For example, adding new types of requires within stable releases is not a good idea (but provides are mostly harmless). New spec sanity checks may seem obvious, but unless its a crasher, chances are somebody is actually (ab)using it and will be unhappy if the package no longer builds. New warnings are generally okay, hard errors often are not.
+    For example, adding new types of requires within stable releases is not a
+    good idea (but provides are mostly harmless). New spec sanity checks may
+    seem obvious, but unless its a crasher, chances are somebody is actually
+    (ab)using it and will be unhappy if the package no longer builds. New
+    warnings are generally okay, hard errors often are not.
 
-    As a rule of thumb: If a package was buildable with rpm-X.Y.Z then it should also be buildable without changes on rpm-X.Y.Z+1, even if it relies on buggy behavior.
+    As a rule of thumb: If a package was buildable with rpm-X.Y.Z then it
+    should also be buildable without changes on rpm-X.Y.Z+1, even if it relies
+    on buggy behavior, except for security issues.
 
 * Does it affect package installation in an incompatible way?
 
-    Rpm is commonly used to install much older and also newer packages built with other versions than the running version, installation compatibility is hugely important always and even more so within stable branches.
+    Rpm is commonly used to install much older and also newer packages built
+    with other versions than the running version, installation compatibility is
+    hugely important always and even more so within stable branches.
 
-    As a rule of thumb: If a package was installable with rpm-X.Y.Z then it should also be installable without changes on rpm-X.Y.Z+1, even if it relies on buggy behavior.
+    As a rule of thumb: If a package was installable with rpm-X.Y.Z then it
+    should also be installable without changes on rpm-X.Y.Z+1, even if it
+    relies on buggy behavior, except for security issues.
 
-If the answer to any of the above is "yes" then its almost certainly not appropriate for stable maintenance release.
+If the answer to any of the above is "yes" then it's almost certainly not
+appropriate for a stable maintenance release.  Mark such a commit with `drop`.
+
+The general priorities for stable branches are (descending order):
+
+1. Regression, crash and security fixes
+2. User visible breakage with no workarounds
+3. User visible breakage with major impact
+4. Other major impact stuff (if [budget](#choosing-a-commit-budget) allows)
+
+#### Choosing a starting point
+
+You may want to skip any commits that were already reviewed in the last release
+(if any).  For a newly created plan, the last `noop` commit is a good
+indication of where the review stopped, but it's a good idea to look a bit
+further back, in case some otherwise suitable commits were omitted due to
+[budget](#choosing-a-commit-budget) constraints and such.  In particular,
+regression or security updates (e.g. rpm-4.15.1.1) tend to include very
+specific cherry-picks, leaving gaps behind that may contain useful material for
+the next stable release.
+
+Otherwise, when editing an existing plan, simply start at the first unmarked
+commit.
+
+Once you've chosen your starting point, either delete the lines above it or
+bookmark the place by inserting an empty line(s) or comment.  It's handy to
+keep the previous commits, though, in case some of them turn out to be needed
+to resolve a conflict.
+
+For a newly created plan, if you choose to keep the previous commits, make sure
+to mark them with `drop`, for example (replace `<linenum>` with the last line
+to mark):
+
+```
+$ sed -i '1,<linenum> s/^     /drop /' <stable>.plan
+```
+
+#### Choosing a commit budget
+
+A useful tool to help you pick and, in particular, *not* pick stuff, is a
+"commit budget".  For stable releases, 30 is a good ballpark figure, but of
+course, feel free to tweak it as needed.
+
+Generally speaking, the budget is for code changes *only*, so any test and
+documentation additions or updates do *not* count and should always be picked
+if possible.
+
+You can check the number of picks so far by running:
+
+```
+$ grep '^pick ' <stable>.plan | wc -l
+```
+
+#### VIM config
+
+If you use VIM, you can add [this](plan.vim) snippet into your `~/.vimrc` to
+cycle through markers on the current line with the `C-a` key and do a `git
+show` with the `Enter` key.
+
+### Sharing a plan
+
+Once you're satisfied with your picks, send the plan as a plain-text email to
+the team and ask for feedback.  That way, people can reply directly to the
+individual commits inline.  Feel free to strip the old commits from the email
+to keep it short.
+
+### Applying a plan
+
+Once the plan is ready, make a copy of the plan and create a topic branch for
+the release (e.g. rpm-4.15.1):
+
+```
+$ cp <stable>.plan <release>.plan
+$ git checkout -b <release>
+```
+
+Then, apply the plan:
+
+```
+$ git cherry-plan apply
+```
+
+This will go through each `pick` commit and run `git cherry-pick -x` on it.
+
+In case a commit doesn't apply cleanly, the process will stop and a message
+will be printed.  At that point, proceed with conflict resolution as usual and
+when committing the changes, make sure to replace the line "(cherry picked from
+commit ...)" with "Backported from commit ...", then run:
+
+```
+$ git cherry-plan mark
+```
+
+This will update the `noop` markers in the plan copy so that they reflect the
+actual branch, i.e. any cherry-picks that were applied successfully above.
+Continue the process by re-running `git cherry-plan apply`.  If another
+conflict occurs, repeat the same process until the plan is applied completely.
+
+While preparing the plan, it can be handy to try this out on a throwaway branch
+every now and then, to make sure you're not missing some pre-requisite
+commit(s).
 
 ## Cutting a release
 


### PR DESCRIPTION
Document the git-native text format for drafting releases that we successfully used for 4.17.1. This is part of #30.