### PR TITLE
Make the ALPHA RN actually useful

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,17 +19,17 @@ capable of
 #### RPM 4.20.0 ALPHA released (Apr 05 2024)
 * See [draft release notes](wiki/Releases/4.20.0) for details and download information
 * Highlights include:
-    * [Declarative buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) support ([#2774](https://github.com/rpm-software-management/rpm/pull/2774))
-    * Dynamic SPEC generation extended ([#2646](https://github.com/rpm-software-management/rpm/pull/2646))
-    * Guaranteed per-build directory ([#2885](https://github.com/rpm-software-management/rpm/pull/2885))
-    * Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#2911](https://github.com/rpm-software-management/rpm/pull/2911))
-    * New prepend and append [modes](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) for build scriptlets ([#2728](https://github.com/rpm-software-management/rpm/pull/2728))
-    * Python bindings have been ported to the stable ABI ([#2674](https://github.com/rpm-software-management/rpm/pull/2674))
-    * Plugin API is now public ([#2661](https://github.com/rpm-software-management/rpm/pull/2661))
-    * Increased isolation of install scriptlets on Linux via a new plugin ([#2666](https://github.com/rpm-software-management/rpm/pull/2666))
-    * File trigger scripts now also receive package count arguments ([#2871](https://github.com/rpm-software-management/rpm/pull/2871), [#2883](https://github.com/rpm-software-management/rpm/pull/2883))
-    * Perl dependency generators have been split out ([#2947](https://github.com/rpm-software-management/rpm/pull/2947))
-    * Internal OpenPGP parser has been removed ([#2986](https://github.com/rpm-software-management/rpm/pull/2986), [#2984](https://github.com/rpm-software-management/rpm/pull/2984))
+    * [Declarative buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) support ([#1087](https://github.com/rpm-software-management/rpm/issues/1087))
+    * Dynamic SPEC generation extended
+    * Guaranteed per-build directory ([#2078](https://github.com/rpm-software-management/rpm/issues/2078))
+    * Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#782](https://github.com/rpm-software-management/rpm/issues/782))
+    * New prepend and append [modes](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) for build scriptlets
+    * Python bindings have been ported to the stable ABI ([#2345](https://github.com/rpm-software-management/rpm/issues/2345))
+    * Plugin API is now public ([#1536](https://github.com/rpm-software-management/rpm/issues/1536))
+    * Increased isolation of install scriptlets on Linux via a new plugin ([#2632](https://github.com/rpm-software-management/rpm/issues/2632), [#2665](https://github.com/rpm-software-management/rpm/issues/2665))
+    * File trigger scripts now also receive package count arguments ([#2755](https://github.com/rpm-software-management/rpm/issues/2755))
+    * Perl dependency generators have been split out ([#2873](https://github.com/rpm-software-management/rpm/issues/2873))
+    * Internal OpenPGP parser has been removed ([#2414](https://github.com/rpm-software-management/rpm/issues/2414))
 
 #### RPM 4.19.1.1 released (Feb 07 2024)
 * This is a bug fix only release addressing a number of regressions, memory

--- a/timeline.md
+++ b/timeline.md
@@ -5,17 +5,17 @@ title: rpm.org - Timeline
 #### RPM 4.20.0 ALPHA released (Apr 05 2024)
 * See [draft release notes](wiki/Releases/4.20.0) for details and download information
 * Highlights include:
-    * [Declarative buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) support ([#2774](https://github.com/rpm-software-management/rpm/pull/2774))
-    * Dynamic SPEC generation extended ([#2646](https://github.com/rpm-software-management/rpm/pull/2646))
-    * Guaranteed per-build directory ([#2885](https://github.com/rpm-software-management/rpm/pull/2885))
-    * Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#2911](https://github.com/rpm-software-management/rpm/pull/2911))
-    * New prepend and append [modes](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) for build scriptlets ([#2728](https://github.com/rpm-software-management/rpm/pull/2728))
-    * Python bindings have been ported to the stable ABI ([#2674](https://github.com/rpm-software-management/rpm/pull/2674))
-    * Plugin API is now public ([#2661](https://github.com/rpm-software-management/rpm/pull/2661))
-    * Increased isolation of install scriptlets on Linux via a new plugin ([#2666](https://github.com/rpm-software-management/rpm/pull/2666))
-    * File trigger scripts now also receive package count arguments ([#2871](https://github.com/rpm-software-management/rpm/pull/2871), [#2883](https://github.com/rpm-software-management/rpm/pull/2883))
-    * Perl dependency generators have been split out ([#2947](https://github.com/rpm-software-management/rpm/pull/2947))
-    * Internal OpenPGP parser has been removed ([#2986](https://github.com/rpm-software-management/rpm/pull/2986), [#2984](https://github.com/rpm-software-management/rpm/pull/2984))
+    * [Declarative buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) support ([#1087](https://github.com/rpm-software-management/rpm/issues/1087))
+    * Dynamic SPEC generation extended
+    * Guaranteed per-build directory ([#2078](https://github.com/rpm-software-management/rpm/issues/2078))
+    * Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#782](https://github.com/rpm-software-management/rpm/issues/782))
+    * New prepend and append [modes](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) for build scriptlets
+    * Python bindings have been ported to the stable ABI ([#2345](https://github.com/rpm-software-management/rpm/issues/2345))
+    * Plugin API is now public ([#1536](https://github.com/rpm-software-management/rpm/issues/1536))
+    * Increased isolation of install scriptlets on Linux via a new plugin ([#2632](https://github.com/rpm-software-management/rpm/issues/2632), [#2665](https://github.com/rpm-software-management/rpm/issues/2665))
+    * File trigger scripts now also receive package count arguments ([#2755](https://github.com/rpm-software-management/rpm/issues/2755))
+    * Perl dependency generators have been split out ([#2873](https://github.com/rpm-software-management/rpm/issues/2873))
+    * Internal OpenPGP parser has been removed ([#2414](https://github.com/rpm-software-management/rpm/issues/2414))
 
 #### RPM 4.19.1.1 released (Feb 07 2024)
 * This is a bug fix only release addressing a number of regressions, memory

--- a/wiki/Releases/4.20.0.md
+++ b/wiki/Releases/4.20.0.md
@@ -5,89 +5,61 @@ title: rpm.org - Releases
 
 # RPM 4.20.0 Release Notes (DRAFT)
 
-Last update: 2024-04-06
+Last update: 2024-04-08
 
 ## Download
 * Source: [rpm-4.19.90.tar.bz2](https://ftp.osuosl.org/pub/rpm/releases/testing/rpm-4.19.90.tar.bz2)
 * SHA256SUM: 93b442e5632d67eff0cd957649e9436b864f61dbe5a0c7c99954fcf14937302c
 
-## Highlights
-* [Declarative buildsystem](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) support ([#2774](https://github.com/rpm-software-management/rpm/pull/2774))
-* Dynamic SPEC generation extended ([#2646](https://github.com/rpm-software-management/rpm/pull/2646))
-* Guaranteed per-build directory ([#2885](https://github.com/rpm-software-management/rpm/pull/2885))
-* Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#2911](https://github.com/rpm-software-management/rpm/pull/2911))
-* New prepend and append [modes](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) for build scriptlets ([#2728](https://github.com/rpm-software-management/rpm/pull/2728))
-* Python bindings have been ported to the stable ABI ([#2674](https://github.com/rpm-software-management/rpm/pull/2674))
-* Plugin API is now public ([#2661](https://github.com/rpm-software-management/rpm/pull/2661))
-* Increased isolation of install scriptlets on Linux via a new plugin ([#2666](https://github.com/rpm-software-management/rpm/pull/2666))
-* File trigger scripts now also receive package count arguments ([#2871](https://github.com/rpm-software-management/rpm/pull/2871), [#2883](https://github.com/rpm-software-management/rpm/pull/2883))
-* Perl dependency generators have been split out ([#2947](https://github.com/rpm-software-management/rpm/pull/2947))
-* Internal OpenPGP parser has been removed ([#2986](https://github.com/rpm-software-management/rpm/pull/2986), [#2984](https://github.com/rpm-software-management/rpm/pull/2984))
-
-## Changelog
+## Changes
 ### Enhancements
-* Command line: Add `--list` and `--delete` commands to rpmkeys ([#2921](https://github.com/rpm-software-management/rpm/pull/2921))
-* Command line: Implement `--json` query format ([#2913](https://github.com/rpm-software-management/rpm/pull/2913))
-* Transaction: Pass arg1 to file trigger scripts ([#2871](https://github.com/rpm-software-management/rpm/pull/2871))
-* Transaction: Pass arg2 to file trigger scripts ([#2883](https://github.com/rpm-software-management/rpm/pull/2883))
-* Packaging: Add build directory auto path to `%autosetup` step ([#2859](https://github.com/rpm-software-management/rpm/pull/2859))
-* Packaging: Add support for declarative buildsystem ([#2774](https://github.com/rpm-software-management/rpm/pull/2774))
-* Packaging: Add support for spec local file attributes and generators ([#2911](https://github.com/rpm-software-management/rpm/pull/2911))
-* Packaging: Add support for sysusers group membership lines ([#2990](https://github.com/rpm-software-management/rpm/pull/2990))
-* Packaging: Allow comments after conditionals ([#2996](https://github.com/rpm-software-management/rpm/pull/2996))
-* Packaging: Allow to specify a default for bcond features in a macro file ([#2405](https://github.com/rpm-software-management/rpm/pull/2405))
-* Packaging: Expose build time to package build scriptlets via `$RPM_BUILD_TIME` ([#2933](https://github.com/rpm-software-management/rpm/pull/2933))
-* Packaging: Implement prepend and append modes for all our normal build scriptlets ([#2728](https://github.com/rpm-software-management/rpm/pull/2728))
-* Packaging: Introduce an rpm-controlled per-build directory ([#2885](https://github.com/rpm-software-management/rpm/pull/2885))
-* Macros: Speed up line macro line number tracking [Optimization] ([#2746](https://github.com/rpm-software-management/rpm/pull/2746))
-* Macros: Support per-user macro configuration in `XDG_CONFIG_HOME` ([#2992](https://github.com/rpm-software-management/rpm/pull/2992))
-* Generators: Support generating dependencies for multiple files at once ([#2537](https://github.com/rpm-software-management/rpm/pull/2537))
-* Python bindings: Use Python Stable ABI for the bindings ([#2674](https://github.com/rpm-software-management/rpm/pull/2674))
-* Build: Allow building rpm without OpenPGP support ([#2984](https://github.com/rpm-software-management/rpm/pull/2984))
-* Build: CMakeLists.txt: eliminate floating dependencies ([#2914](https://github.com/rpm-software-management/rpm/pull/2914))
-* Build: Make our plugin directory a global cache configurable and export it ([#2688](https://github.com/rpm-software-management/rpm/pull/2688))
-* Plugins: Add a new plugin to enable Linux-specific namespace functionality ([#2666](https://github.com/rpm-software-management/rpm/pull/2666))
-* Plugins: Make the plugin API public ([#2661](https://github.com/rpm-software-management/rpm/pull/2661))
+* Support for [declarative buildsystems](https://rpm-software-management.github.io/rpm/manual/buildsystem.html) ([#1087](https://github.com/rpm-software-management/rpm/issues/1087))
+* A per-package build directory that's fully RPM-controlled is now used and exposed as the new `%builddir` macro at build time ([#2078](https://github.com/rpm-software-management/rpm/issues/2078))
+* Support for [SPEC-local](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#using-file-attributes-in-their-own-package) file attributes and generators ([#782](https://github.com/rpm-software-management/rpm/issues/782))
+* New `--list` and `--delete` commands to `rpmkeys(8)`
+* New `--json` query format, as a more readable alternative to `--xml`
+* A new `-C` option in `%autosetup` which ensures that the sources will be extracted in the root of the build directory ([#2664](https://github.com/rpm-software-management/rpm/issues/2664))
+* A new low-level package dump utility, installed as `/usr/lib/rpm/rpmdump`
+* Build scriptlets (such as `%build`, `%install` or `%check`) can now be [augmented](https://rpm-software-management.github.io/rpm/manual/spec.html#build-scriptlets) arbitrary number of times by appending or prepending to them with the new `-a` and `-p` options
+* The `rpm2archive(8)` utility now supports cpio file format, replacing the implementation of `rpm2cpio(8)` which is now installed as a symlink to the former
+* File trigger scripts now receive package count arguments, much like regular triggers ([#2755](https://github.com/rpm-software-management/rpm/issues/2755))
+* Group membership lines are now supported in `sysusers.d(5)` files
+* Comments (starting with a `#`) are now allowed after SPEC conditionals
+* Indentation is now [allowed](https://rpm-software-management.github.io/rpm/manual/spec.html#preamble-tags) for SPEC tags ([#2927](https://github.com/rpm-software-management/rpm/issues/2927))
+* Distributions can now override build conditionals (`%bcond`) system-wide with the new `%{bcond_override_default NAME VALUE}` macro
+* The build time is now exposed to build scriptlets via the new `$RPM_BUILD_TIME` environment variable
+* The `${XDG_CONFIG_HOME}/rpm` directory is now the preferred location when loading per-user macro configuration ([#2153](https://github.com/rpm-software-management/rpm/issues/2153))
+* A new [multi-file protocol](https://rpm-software-management.github.io/rpm/manual/dependency_generators.html#writing-dependency-generators) allowing for much faster dependency generation
+* The Python bindings have been ported to the stable Python ABI ([#2345](https://github.com/rpm-software-management/rpm/issues/2345))
+* RPM can now be built without OpenPGP support, allowing for easier bootstrapping (see the INSTALL file for details)
+* A new plugin `rpm-plugin-unshare(8)` that allows for using various Linux-specific namespace-related technologies inside transactions, such as to harden and limit scriptlet access to resources ([#2632](https://github.com/rpm-software-management/rpm/issues/2632), [#2665](https://github.com/rpm-software-management/rpm/issues/2665))
+* The plugin API is now public ([#1536](https://github.com/rpm-software-management/rpm/issues/1536))
+* The OpenSSL code has been moved to newer API ([#2723](https://github.com/rpm-software-management/rpm/issues/2294))
 
 ### Changes
-* Packaging: Reword "`%changelog` is missing" warning [Cosmetic] ([#2943](https://github.com/rpm-software-management/rpm/pull/2943))
-* Packaging: Allow whitespace before directives in the Preamble ([#2957](https://github.com/rpm-software-management/rpm/pull/2957))
-* Packaging: Convert `%prep` into a regular build scriptlet ([#2730](https://github.com/rpm-software-management/rpm/pull/2730))
-* Packaging: Don't brp-strip ruby, python, or javascript files ([#2858](https://github.com/rpm-software-management/rpm/pull/2858))
-* Generators: Remove perl dependency generators from the repo ([#2947](https://github.com/rpm-software-management/rpm/pull/2947))
-
-### Deprecations
-* Packaging: Allow comments after conditionals ([#2996](https://github.com/rpm-software-management/rpm/pull/2996))
-* Split the internal OpenPGP parser to a separate repository ([#2986](https://github.com/rpm-software-management/rpm/pull/2986))
+* The deprecated internal OpenPGP parser has now been removed ([#2414](https://github.com/rpm-software-management/rpm/issues/2414))
+* The Perl dependency generators have been split out of the main repository ([#2873](https://github.com/rpm-software-management/rpm/issues/2873))
+* `brp-strip` no longer strips Ruby, Python and Javascript files
 
 ### Fixes
-* Command line: Set the charset of the libarchive strings to utf8 ([#2993](https://github.com/rpm-software-management/rpm/pull/2993))
-* Command line: rpm2archive: fix hardlink handling in cpio output ([#2975](https://github.com/rpm-software-management/rpm/pull/2975))
-* Transaction: Ignore `%config` flag where not supported ([#2906](https://github.com/rpm-software-management/rpm/pull/2906))
-* Transaction: Ignore non-scriptlet weak dependencies in ordering ([#3004](https://github.com/rpm-software-management/rpm/pull/3004))
-* Packaging: Ensure binary and source headers are identified as such after parse [Regression] ([#3012](https://github.com/rpm-software-management/rpm/pull/3012))
-* Packaging: Never use current user info or file ownership during build [Regression] ([#2797](https://github.com/rpm-software-management/rpm/pull/2797))
-* Packaging: Ensure rpmbuild's cleanup doesn't fail due to permissions ([#3006](https://github.com/rpm-software-management/rpm/pull/3006))
-* Packaging: Let eBPF ELF files be packaged in noarch packages ([#2902](https://github.com/rpm-software-management/rpm/pull/2902))
-* Packaging: Really allow qualifiers like pre/post/meta for weak dependencies ([#2964](https://github.com/rpm-software-management/rpm/pull/2964))
-* Packaging: Run build scriptlets with closed stdin to enforce unattended builds ([#2898](https://github.com/rpm-software-management/rpm/pull/2898))
-* Packaging: Set git commit dates based on `$SOURCE_DATE_EPOCH` ([#2930](https://github.com/rpm-software-management/rpm/pull/2930))
-* Macros: Issue a warning when passing arguments to non-parametric macros [Cosmetic] ([#2940](https://github.com/rpm-software-management/rpm/pull/2940))
-* Macros: Make `%dirname` and `%basename` behave like `dirname(3)` and `basename(3)` ([#2945](https://github.com/rpm-software-management/rpm/pull/2945))
-* Macros: Strip quote characters in macro expansion if we do not split the result ([#2788](https://github.com/rpm-software-management/rpm/pull/2788))
-* Generators: Fix dependency generators sometimes dying with `SIGPIPE` [Regression] ([#2958](https://github.com/rpm-software-management/rpm/pull/2958))
-* Python bindings: Return false when comparing different python objects holding the same version tag ([#2838](https://github.com/rpm-software-management/rpm/pull/2838))
-* Python bindings: Support rpmver-py comparison operator inheritance ([#2839](https://github.com/rpm-software-management/rpm/pull/2839))
-
-### Security
-* Build: Allow building rpm without OpenPGP support ([#2984](https://github.com/rpm-software-management/rpm/pull/2984))
-* Move OpenSSL code to newer API ([#2723](https://github.com/rpm-software-management/rpm/pull/2723))
-* Split the internal OpenPGP parser to a separate repository ([#2986](https://github.com/rpm-software-management/rpm/pull/2986))
+* `rpm2archive(8)` now writes compliant cpio archives again ([#2974](https://github.com/rpm-software-management/rpm/issues/2974))
+* Ignore `%config` usage with unsupported file entries (i.e. with anything else than regular files or links) instead of failing the build ([#2890](https://github.com/rpm-software-management/rpm/issues/2890))
+* Ignore non-scriptlet weak dependencies in ordering ([#1346](https://github.com/rpm-software-management/rpm/issues/1346))
+* Ensure binary and source headers are identified as such after parse (Regression) ([#2819](https://github.com/rpm-software-management/rpm/issues/2819))
+* Never use current user info or file ownership during build (Regression) ([#2604](https://github.com/rpm-software-management/rpm/issues/2604))
+* Ensure rpmbuild's cleanup doesn't fail due to permissions ([#2519](https://github.com/rpm-software-management/rpm/issues/2519))
+* Let eBPF ELF files be packaged in noarch packages ([#2875](https://github.com/rpm-software-management/rpm/issues/2875))
+* Really allow qualifiers like pre/post/meta for weak dependencies ([#624](https://github.com/rpm-software-management/rpm/issues/624))
+* Set git commit dates in `%autosetup -S git` based on `$SOURCE_DATE_EPOCH` ([#9](https://pagure.io/fedora-reproducible-builds/project/issue/9))
+* Issue a warning when passing arguments to non-parametric macros ([#2932](https://github.com/rpm-software-management/rpm/issues/2932))
+* Make `%dirname` and `%basename` behave like `dirname(3)` and `basename(3)` ([#2928](https://github.com/rpm-software-management/rpm/issues/2928))
+* Fix dependency generators sometimes dying with `SIGPIPE` (Regression) ([#2949](https://github.com/rpm-software-management/rpm/issues/2949))
+* Run build scriptlets with closed stdin to enforce unattended builds
 
 ## Compatibility notes
 * The `%patchN` macro syntax (where `N` is a patch number) is now obsolete and
   will produce a build error.  Use `%patch N` (or `%patch -P N`) instead.
 * Comments after SPEC conditionals are now valid syntax (and won't cause a
   warning), any other text that doesn't start with a `#` is now an error.
-* The `rpm2cpio(8)` utility has been [removed](https://github.com/rpm-software-management/rpm/pull/2758) in favor of `rpm2archive(8)`.
-* Python 3.7 and OpenSSL 3.0 are now the minimum build requirements.
+* Python 3.7 and OpenSSL 3.0 (when enabled) are now the minimum build
+  requirements.


### PR DESCRIPTION
Abandon the idea of auto-generating the changelog, its purpose is to inform the users about the changes, not list the applied PRs.  See also: https://keepachangelog.com/

Instead of linking to PRs, link to actual issues behind those PRs.  As part of that, remove (most) entries that don't have an associated issue, those often aren't user-visible changes anyway.

Lastly, also abandon the use of arbitrary category prefixes/postfixes, they just never feel right and are mostly just noise.

The changelog script is still useful as raw input but there *is* value in hand-crafted changelogs, actually.  This realization comes from today's team chat.