### PR TITLE
Use a Different archive.org Snapshot for the Fedora RPM Guide

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -14,7 +14,7 @@ This page attempts to track the various relevant documentation that exists for R
 * [RPM Database Recovery](user_doc/db_recovery.html)
 
 ## Packager Documentation
-* [Fedora RPM Guide](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html)
+* [Fedora RPM Guide](https://web.archive.org/web/20170608211215/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html)
 * [RPM Guide](https://rpm-packaging-guide.github.io/) - A good introduction into RPM Packaging
 * [Building Packages so that multiple versions of the same package can co-install](user_doc/multiple_versions.html)
 
@@ -25,13 +25,13 @@ This page attempts to track the various relevant documentation that exists for R
   * [RPM 4.18.x](https://ftp.osuosl.org/pub/rpm/api/4.18.0/)
   * [Older versions](https://ftp.osuosl.org/pub/rpm/api/)
 
-* [Programming RPM with C](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-c.html) from Fedora RPM Guide
+* [Programming RPM with C](https://web.archive.org/web/20170608211215/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-c.html) from Fedora RPM Guide
 * [How to ensure Large File Support for tools using the rpm API](devel_doc/large_files.html)
 
 ## RPM Language Bindings
 * [RPM Python](https://web.archive.org/web/20050320013335/http://www.ukuug.org/events/linux2004/programme/paper-PNasrat-1/rpm-python-slides/frames.html) slideset / tutorial by Paul Nasrat (2004)
-* [Programming RPM with Python](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-rpm-programming-python.html) from Fedora RPM Guide
-* [Programming RPM with Perl](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-perl.html) from Fedora RPM Guide
+* [Programming RPM with Python](https://web.archive.org/web/20170608211215/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-rpm-programming-python.html) from Fedora RPM Guide
+* [Programming RPM with Perl](https://web.archive.org/web/20170608211215/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-perl.html) from Fedora RPM Guide
 
 ## Miscellaneous Developer Docs:
   * [Release maintaince](devel_doc/release_maintaince.html)
@@ -41,7 +41,7 @@ This page attempts to track the various relevant documentation that exists for R
 The following books have been published regarding RPM:
 
 * **Maximum RPM** A 1997 book written by Ed Bailey. It is available in hardback (442 pages), and then re-printed by Sams in soft-cover (450 pages - ISBN: 0672311054). The hardcover edition includes a quick reference card. An [on-line version of the original book](https://cdn.preterhuman.net/texts/manuals/Maximum_RPM.pdf) is also available, as is a [more updated date version](https://ftp.osuosl.org/pub/rpm/max-rpm/).
-* **Red Hat RPM Guide** A 2003 book by [Eric Foster-Johnson](https://foster-johnson.com/), this has been released later under the Open Publication License and a draft close to the published version is available on-line as [Fedora RPM Guide](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html). This book covers everything from basic usage to advanced tricks, package creation and API programming.
+* **Red Hat RPM Guide** A 2003 book by [Eric Foster-Johnson](https://foster-johnson.com/), this has been released later under the Open Publication License and a draft close to the published version is available on-line as [Fedora RPM Guide](https://web.archive.org/web/20170608211215/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html). This book covers everything from basic usage to advanced tricks, package creation and API programming.
 
 ## Other Resources
 * [Software related to rpm](software.html)

--- a/documentation.md
+++ b/documentation.md
@@ -9,7 +9,7 @@ This page attempts to track the various relevant documentation that exists for R
 * [RPM Reference Manual](https://rpm-software-management.github.io/rpm/manual/)
 * [RPM man pages](https://rpm-software-management.github.io/rpm/man/)
 * [Fedora News RPM Tutorial](http://fedoranews.org/alex/tutorial/rpm/)
-* [Fedora RPM Guide](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html)
+* [Fedora RPM Guide](https://web.archive.org/web/20170608211215/https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/index.html)
 * [RPM Frequently asked questions (FAQ)](user_doc/faq.html)
 * [RPM Database Recovery](user_doc/db_recovery.html)
 
@@ -31,7 +31,7 @@ This page attempts to track the various relevant documentation that exists for R
 ## RPM Language Bindings
 * [RPM Python](https://web.archive.org/web/20050320013335/http://www.ukuug.org/events/linux2004/programme/paper-PNasrat-1/rpm-python-slides/frames.html) slideset / tutorial by Paul Nasrat (2004)
 * [Programming RPM with Python](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-rpm-programming-python.html) from Fedora RPM Guide
-* [Programming RPM with Perl](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-perl.html) from Fedora RPM Guide 
+* [Programming RPM with Perl](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/ch-programming-perl.html) from Fedora RPM Guide
 
 ## Miscellaneous Developer Docs:
   * [Release maintaince](devel_doc/release_maintaince.html)
@@ -40,8 +40,8 @@ This page attempts to track the various relevant documentation that exists for R
 ## Books
 The following books have been published regarding RPM:
 
-* **Maximum RPM** A 1997 book written by Ed Bailey. It is available in hardback (442 pages), and then re-printed by Sams in soft-cover (450 pages - ISBN: 0672311054). The hardcover edition includes a quick reference card. An [on-line version of the original book](https://cdn.preterhuman.net/texts/manuals/Maximum_RPM.pdf) is also available, as is a [more updated date version](https://ftp.osuosl.org/pub/rpm/max-rpm/). 
-* **Red Hat RPM Guide** A 2003 book by [Eric Foster-Johnson](https://foster-johnson.com/), this has been released later under the Open Publication License and a draft close to the published version is available on-line as [Fedora RPM Guide](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html). This book covers everything from basic usage to advanced tricks, package creation and API programming. 
+* **Maximum RPM** A 1997 book written by Ed Bailey. It is available in hardback (442 pages), and then re-printed by Sams in soft-cover (450 pages - ISBN: 0672311054). The hardcover edition includes a quick reference card. An [on-line version of the original book](https://cdn.preterhuman.net/texts/manuals/Maximum_RPM.pdf) is also available, as is a [more updated date version](https://ftp.osuosl.org/pub/rpm/max-rpm/).
+* **Red Hat RPM Guide** A 2003 book by [Eric Foster-Johnson](https://foster-johnson.com/), this has been released later under the Open Publication License and a draft close to the published version is available on-line as [Fedora RPM Guide](https://web.archive.org/web/20220628164331/docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html//RPM_Guide/index.html). This book covers everything from basic usage to advanced tricks, package creation and API programming.
 
 ## Other Resources
 * [Software related to rpm](software.html)


### PR DESCRIPTION
The 2022 snapshot is incomplete, clicking on links in the table of content leads to a "page not found".

The 2017 snapshot seems to be the most recent snapshot that seems complete (I clicked on about 10 links in the ToC and they all worked)