### PR TITLE
CSS: Prevent unnecessary scrollbars

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -105,7 +105,6 @@ p img {
 }
 
 pre, code {
-  width: 100%;
   color: #222;
   background-color: #fff;
 


### PR DESCRIPTION
Having both PRE and CODE set to 100% width causes every code block to have a slight horizontal scrollbar, at least in Chrome 134 on Linux. (It also doesn't make sense for CODE, which is also used inline. Fortunately display:inline prevents the width from applying in those cases.)

PRE is already styled width:100% a few lines farther down, so the width eliminated is mostly redundant anyway.

## Before
![image](https://github.com/user-attachments/assets/77c78d9d-1d07-4d89-921d-dbf88f81e20d)

## After
![image](https://github.com/user-attachments/assets/a5bbed08-f967-4c63-9f58-a44098274302)
