### PR TITLE
Update 6.0 release notes for beta2

### DIFF
--- a/_releases/5.99.92.md
+++ b/_releases/5.99.92.md
@@ -1,0 +1,25 @@
+---
+version: 6.0.0
+snapshot: beta2
+checksum: 4c63ed93365e3f5449d8ae573555e3d08f9f5b64e71f746bbeb3ec776283eee1
+date: 2025-08-27
+summary:
+    This is the second beta release of 6.0, the main changes being support
+    for OpenPGP v6 signatures and various bugfixes, especially to package
+    signing
+---
+
+* Fix fingerprinting regression in 6.0 alpha (#3762)
+* Fix rpmsign possibly adding multiple legacy tags (#3878)
+* Fix rpmsign possibly copying a OpenPGP v6 signature into legacy tag (#3851)
+* Fix regression on signature size reservation not being used (#3768)
+* Fix race condition in brp-strip-comment-note (#3868)
+* Fix segfault on invalid output from multi-mode dependency generator (#3821)
+* Fix Lua `rpm.glob()` not honoring the `c` argument (#3794)
+* Fix alternatives mechanism unintentionally kicking in for signatures (#3872)
+* Fix sources and patches stored in reverse order in headers (#3014)
+* Add support for OpenPGP v6 signatures (#3845, #3846)
+* Add SHA512 payload digest to appease CNSA 2.0 (#3894)
+* Add *rpm-manifest*(5) man page (#3650)
+* Drop pre-4.6 `rpmlib()` dependencies from v6 packages
+

--- a/_releases/6.0.0.md
+++ b/_releases/6.0.0.md
@@ -1,7 +1,7 @@
 ---
 version: 6.0.0
 baseline: 4.20.1
-date: 2025-07-01
+date: 2025-08-27
 draft: true
 heading_offset: 2
 ---
@@ -9,9 +9,9 @@ heading_offset: 2
 * RPM defaults to enforcing signature checking (#1573)
 * RPM uses the full key ID or fingerprint to identify OpenPGP keys everywhere (#2403)
 * Support for multiple OpenPGP signatures per package (#3385)
-* Support for OpenPGP v6 and PQC keys and signatures (#3363, work in progress)
+* Support for OpenPGP v6 and PQC keys and signatures (#3363)
 * Support for updating previously imported keys (#2577)
-* Support for both RPM v4 and v6 packages
+* Support for both RPM v4 and v6 packages (see [Compatibility Notes](#compatibility-notes))
 * Support for installing RPM v3 packages has been removed (#1107)
 * Man page overhaul (work in progress)
 * Pristine and verifiable release tarballs (#3565) (#2702)
@@ -32,8 +32,9 @@ heading_offset: 2
 * Several enhancements to *rpmsign*(1):
   * `rpmsign` can use either GnuPG or Sequoia-sq for signing (controlled
     by `%_openpgp_sign` macro (`gpg` or `sq`))
-  * `rpmsign --addsign` always adds a new signature (arbitrary number of
-    signatures supported now)
+  * `rpmsign --addsign` no longer replaces existing signatures. Arbitrary
+    number of signatures can be added on v6 packages by default and
+    on v4 packages, with `--rpmv6`
   * `rpmsign --resign` replaces all existing signatures with a new one
 * New query tag extensions (e.g. with `--qf <format>`):
   * `rpmformat` for determining package format version (3/4/6)
@@ -53,11 +54,12 @@ heading_offset: 2
   * Update all manual pages to a new consistent style (#3669)
   * Add man pages for all major components and file formats (#3612)
     * *rpm-config*(5)
-    * *rpm-payloadflags*(7)
     * *rpm-rpmrc*(5)
     * *rpm-macrofile*(5)
+    * *rpm-manifest*(5)
     * *rpm-lua*(7)
     * *rpm-macros*(7)
+    * *rpm-payloadflags*(7)
     * *rpm-queryformat*(7)
   * Move end-user commands to section 1
   * Many previously undocumented things covered, many errors fixed
@@ -67,25 +69,18 @@ heading_offset: 2
   * API docs
 
 ### Packaging
-* *rpmbuild*(1) now supports generating two different package formats
-  (controlled by `%_rpmformat` macro):
+* *rpmbuild*(1) now supports generating two different package formats,
+  controlled by `%_rpmformat` macro value `6`/`4`:
   * [RPM v6](https://rpm-software-management.github.io/rpm/manual/format_v6.html)
-    * All file sizes and related limits are 64bit
-    * Crypto modernization
-      * Obsolete crypto (MD5 and SHA1) dropped
-      * SHA3 header and payload digests added (#3797, #3642)
-    * Per-file MIME info
-    * Widely compatible with RPM >= 4.14
-    * The "external" dependency generator mode no longer supported with
-      v6 packages (#2373)
   * [RPM v4](https://rpm-software-management.github.io/rpm/manual/format_v4.html)
-    * Bit-per-bit compatible with packages produced by RPM 4.x
 * *rpmbuild*(1) can now automatically sign packages if `%_openpgp_autosign_id`
   macro is defined (#2678)
 * New command *rpm-setup-autosign*(1) added for easy auto-signing configuration
   (#3522)
 * New `%{span:...}` macro to make defining multi-line macros nicer
 * New `%{xdg:...}` macro for evaluating XDG base directories
+* Fix sources and patches stored in reverse order in the header (#3014)
+* Fix Lua `rpm.glob()` not honoring the `c` argument (#3794)
 * Fix architecture checking accidentally moved after build (#3569)
 * Fix buildsys specific `%prep` section not accepted (#3635)
 * Fix `check-rpaths` brp script when both RPATH and RUNPATH exist (#3667)
@@ -93,6 +88,8 @@ heading_offset: 2
 * Fix 4.20 regression on `rpmbuild -rs` failing on non-existent directory
   (#3682)
 * Fix an extra newline printed on `rpm --eval`
+* Fix a segfault on invalid dependency generator output in `multi` mode (#3821)
+* Fix `brp-strip-comment-note` failure due to a race condition
 * `brp-elfperms` buildroot policy script was removed (#3195)
 
 ### API Changes
@@ -122,8 +119,8 @@ heading_offset: 2
 * New rpm tags:
   `RPMTAG_PAYLOADSIZE`, `RPMTAG_PAYLOADSIZEALT`, `RPMTAG_RPMFORMAT`,
   `RPMTAG_FILEMIMEINDEX`, `RPMTAG_MIMEDICT`, `RPMTAG_FILEMIMES`,
-  `RPMTAG_SOURCENEVR`, `RPMTAG_PAYLOADSHA3_256`, `RPMTAG_PAYLOADSHA3_256ALT`,
-  `RPMTAG_SHA3_256HEADER`
+  `RPMTAG_SOURCENEVR`, `RPMTAG_PAYLOADSHA512`, `RPMTAG_PAYLOADSHA512ALT`,
+  `RPMTAG_PAYLOADSHA3_256`, `RPMTAG_PAYLOADSHA3_256ALT`, `RPMTAG_SHA3_256HEADER`
 * Renamed rpm tags:
   * `RPMTAG_PAYLOADDIGEST` to `RPMTAG_PAYLOADSHA256`
   * `RPMTAG_PAYLOADDIGESTALT` to `RPMTAG_PAYLOADSHA256ALT`
@@ -134,6 +131,10 @@ heading_offset: 2
   * `rpmfilesFMime()`, `rpmfiFMime()` for retrieving per-file MIME info
   * `RPMFI_NOFILEMIME` flag to control behavior
 * New OpenPGP identifiers related to RFC-9580 added
+* New `pgpDigParamsSalt()` function retrieving OpenPGP v6 signature pre-salt
+  (#3846)
+* New `rpmDigestBundleUpdateID()` function for updating individual ID's in
+  a digest bundle (#3845)
 * `rpmtsAddInstallElement()` returns `3` on unsupported package format
 * `fdSize()` returns an error on non-regular files
 
@@ -148,7 +149,10 @@ heading_offset: 2
 * New `openpgp.cert.d` based keystore (experimental) (#3341)
 * New `make site` build target for easy local rendering of documentation
 * Make reference counting atomic throughout the codebase
+* Make the test-suite image `toolbox(1)` ready
 * Support underscores in RPMTAG names
+* Fix 4.20 regression signature size reservation not being used (#3768)
+* Fix alternatives mechanism unintentionally kicking in for signatures (#3872)
 * Fix keystore reads lacking transaction lock
 * Fix a race condition in `rpmioMkpath()` (#3508)
 * Fix recursion depth for macro error message (#3197)
@@ -173,7 +177,7 @@ heading_offset: 2
 ### Building RPM
 * A C++20 compiler is now required in addition to a C99 compiler, but
   C++20 modules support is not required.
-* rpm-sequoia >= 1.8.0 is now required for building with Sequoia (default)
+* rpm-sequoia >= 1.9.0 is now required for building with Sequoia (default)
 * Python >= 3.10 is now required for building the Python bindings
 * [scdoc](https://git.sr.ht/~sircmpwn/scdoc) man page generator is now
   required for building RPM
@@ -184,19 +188,31 @@ heading_offset: 2
 
 ### Compatibility Notes
 #### Package format
-* Support for installing RPM v3 packages has been removed. (#1107)
-  They can still be queried and also unpacked with *rpm2cpio*(1).
-* RPM v4 packages remain fully supported, but:
+* New RPM v6 package format
+  * All file sizes and related limits are 64bit
+  * Crypto modernization
+    * Obsolete crypto (MD5 and SHA1) dropped
+    * SHA3-256 header digest added (#3797)
+    * SHA512 and SHA3-256 payload digests added (#3642, #3894)
+  * Per-file MIME info
+  * Widely compatible with RPM >= 4.14
+  * The "external" dependency generator mode no longer supported with
+    v6 packages (#2373)
+  * `rpmlib()` dependencies for pre-4.6 features removed to reduce clutter (#3854)
+  * Can be queried with RPM >= 4.6
+  * Can be unpacked with RPM >= 4.12
+  * Can be verified and installed with RPM >= 4.14 (with caveats/limitations)
+* RPM v4 packages:
+  * Built packages are identical to those generated by RPM 4.x versions
+  * Remain fully supported
   * In the default configuration, packages built with RPM < 4.14.0 cannot
     be verified due to their use of weak, obsolete MD5 and SHA1 digests.
     For strongly signed packages, this can be worked around by changing
     `%_pkgverify_level` to `signature` so the weak digests are simply ignored.
     If verifying the weak digests is necessary, the RPM 4.x behavior can
     be restored by setting `%_pkgverify_flags` to `0`.
-* RPM v6 packages
-  * Can be queried with RPM >= 4.6
-  * Can be unpacked with RPM >= 4.12
-  * Can be verified and installed with RPM >= 4.14 (with caveats/limitations)
+* Support for installing RPM v3 packages has been removed. (#1107)
+  They can still be queried and also unpacked with *rpm2cpio*(1).
 * RPM defaults to building v6 packages, this can be changed with the
   `%_rpmformat` macro.
 * Lua `posix.fork()` family of calls, deprecated in 4.20, is disabled in


### PR DESCRIPTION
Also move the v6 format details from package building to the compatibility notes section, seems like a better fit there