### PR TITLE
Use Ubuntu 24.04 as the GH runner

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The "latest" label currently points to 24.04 but let's stick to a specific version here, rather than risking unexpected breakage in the future. This is also what we use in the main rpm repo's workflow.