### PR TITLE
Drop the "stable" distinction in release listings

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -7,7 +7,6 @@
     - 6.1.x
     - 6.0.x
     - 4.20.x
-    - 4.19.x
   repourl: https://github.com/rpm-software-management/rpm
   tarball:
     baseurl: https://ftp.osuosl.org/pub/rpm/releases
@@ -42,12 +41,5 @@
         podman build --target base --tag rpm/web -f tests/Dockerfile .
         podman run -it --rm -v $PWD:/srv:z --workdir /srv rpm/web sh -c \
           "cmake -B _build -DWITH_DOXYGEN=ON && make -C _build apidoc"
-        cp -r _build/docs/html $DESTDIR/api
-        cp -r _build/docs/index.md docs/manual docs/man $DESTDIR/
-    - series: 4.19.x
-      build: |
-        podman build --target base --tag rpm/web -f tests/Dockerfile .
-        podman run -it --rm -v $PWD:/srv:z --workdir /srv rpm/web sh -c \
-          "cmake -B _build -DENABLE_TESTSUITE=OFF && make -C _build apidoc"
         cp -r _build/docs/html $DESTDIR/api
         cp -r _build/docs/index.md docs/manual docs/man $DESTDIR/

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -13,7 +13,6 @@
     baseurl: https://ftp.osuosl.org/pub/rpm/releases
     fileext: tar.bz2
   manual:
-    baseurl: https://rpm-software-management.github.io/rpm/man
     pattern: '\*(rpm[-\.[:alnum:]]*|gendiff|elfdeps)\*\(([1-8])\)'
   ticket:
     baseurl: https://github.com/rpm-software-management/rpm/issues
@@ -25,8 +24,6 @@
     baseurl: https://bugzilla.redhat.com
     pattern: '\(RhBug:([0-9]+)\)'
   docs:
-    - series: 6.2.x
-      baseurl: https://rpm-software-management.github.io/rpm
     - series: 6.1.x
       build: |
         podman build --target base --tag rpm/web -f tests/Dockerfile .

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -4,6 +4,7 @@
   series_re: ^([0-9]+\.[0-9]+)\..+$
   # Supported stable series
   stable:
+    - 6.1.x
     - 6.0.x
     - 4.20.x
     - 4.19.x
@@ -24,8 +25,14 @@
     baseurl: https://bugzilla.redhat.com
     pattern: '\(RhBug:([0-9]+)\)'
   docs:
-    - series: 6.1.x
+    - series: 6.2.x
       baseurl: https://rpm-software-management.github.io/rpm
+    - series: 6.1.x
+      build: |
+        podman build --target base --tag rpm/web -f tests/Dockerfile .
+        podman run -it --rm -v $PWD:/srv:z --workdir /srv rpm/web sh -c \
+          "cmake -B _build -DWITH_DOXYGEN=ON && make -C _build pages"
+        cp -r _build/site/{index.md,manual,man,api} $DESTDIR/
     - series: 6.0.x
       build: |
         podman build --target base --tag rpm/web -f tests/Dockerfile .

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -2,8 +2,8 @@
   title: RPM
   # Pattern to extract version series
   series_re: ^([0-9]+\.[0-9]+)\..+$
-  # Supported stable series
-  stable:
+  # Supported version series
+  series:
     - 6.1.x
     - 6.0.x
     - 4.20.x

--- a/_plugins/release.rb
+++ b/_plugins/release.rb
@@ -37,9 +37,6 @@ module Release
         # Construct series
         series = version.gsub(/#{prodata['series_re']}/, '\1.x')
 
-        # Determine if supported
-        supported = prodata['stable'].include? series
-
         # Construct tarball URL
         tarball = prodata['tarball']
         baseurl = tarball['baseurl']
@@ -63,7 +60,6 @@ module Release
         data['series'] = series
         data['snapshot'] = snapshot
         data['baseline'] = baseline
-        data['supported'] = supported
         data['tarball'] = tarball
 
         # Merge parent snapshot if draft
@@ -81,11 +77,7 @@ module Release
         parent = page
 
         # Convert man page references to links
-        if supported then
-          baseurl = "/docs/#{series}/man"
-        else
-          baseurl = prodata['manual']['baseurl']
-        end
+        baseurl = "/docs/#{series}/man"
         pattern = prodata['manual']['pattern']
         page.content = page.content.gsub(
           /#{pattern}/, '[\1(\2)]('"#{baseurl}"'/\1.\2)')

--- a/build-docs
+++ b/build-docs
@@ -36,7 +36,8 @@ build() {
     done
 
     # Create latest "alias"
-    cp -r $DEST_DIR/$latest $DEST_DIR/latest
+    mkdir -p $DEST_DIR/latest
+    cp -r $DEST_DIR/$latest/* $DEST_DIR/latest/
 }
 
 for project in $(yq ".[].name"); do

--- a/build-docs
+++ b/build-docs
@@ -16,7 +16,7 @@ build() {
     local name=$1
     local query=".[] | select(.name == \"$name\")"
     local repo_url=$(yq "${query}.repourl")
-    local latest=$(yq "${query}.stable[0]")
+    local latest=$(yq "${query}.series[0]")
     local repo_dir=$SCRIPT_DIR/_build/$name
     local src_path dst_path
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@ title: rpm.org - Documentation
 
 <ul>
 {% assign latest = true %}
-{% for series in project.stable %}
+{% for series in project.series %}
     <li>
         <a href="{{ series }}">{{ project.title }} {{ series }}</a>
         {% if latest %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,15 @@ title: rpm.org - Documentation
 ---
 
 {% assign project = site.data.projects | where: "name", "rpm" | first %}
-{% assign docs = project.docs | sort: "series" | reverse %}
 
 <h2>Documentation</h2>
 <p>Reference documentation shipped with RPM.</p>
 
-<h3>Stable Releases</h3>
 <ul>
 {% assign latest = true %}
-{% for tree in docs %}
-    {% if project.stable contains tree.series %} {% else %} {% continue %} {% endif %}
+{% for series in project.stable %}
     <li>
-        <a href="{{ tree.series }}/">{{ project.title }} {{ tree.series }}</a>
+        <a href="{{ series }}">{{ project.title }} {{ series }}</a>
         {% if latest %}
             (<a href="latest/">latest</a>)
             {% assign latest = false %}
@@ -24,21 +21,13 @@ title: rpm.org - Documentation
 {% endfor %}
 </ul>
 
-<h3>Development</h3>
-<ul>
-{% for tree in docs %}
-    {% if project.stable contains tree.series %} {% continue %} {% endif %}
-    {% if tree.baseurl %}
-        {% assign baseurl = tree.baseurl %}
-    {% else %}
-        {% assign baseurl = tree.series %}
-    {% endif %}
-    <li>
-        <a href="{{ baseurl }}/">{{ project.title }} {{ tree.series }}</a>
-    </li>
-{% endfor %}
-</ul>
+<p>
+    A development preview is also
+    <a href="https://rpm-software-management.github.io/rpm">available</a>.
+</p>
 
-See also a collection of <a href="howto">HOWTOs</a>, older
-<a href="https://ftp.osuosl.org/pub/rpm/api/">API docs</a> and
-<a href="resources">external resources</a>.
+<p>
+    See also a collection of <a href="howto">HOWTOs</a>, older
+    <a href="https://ftp.osuosl.org/pub/rpm/api/">API docs</a> and
+    <a href="resources">external resources</a>.
+</p>

--- a/releases/index.html
+++ b/releases/index.html
@@ -7,42 +7,31 @@ title: rpm.org - Releases
 
 <h2>Releases</h2>
 
-<h3>Stable</h3>
-{% assign series_list = site.releases |
-    where: "draft", false |
-    where: "snapshot", false |
-    where: "supported", true |
-    sort: "series" | reverse | group_by: "series" %}
-{% for series in series_list %}
-    <h4>{{ project.title }} {{ series.name }}</h4>
+{% for series in project.stable %}
+    <h4>{{ project.title }} {{ series }}</h4>
     <ul>
-    {% for release in series.items %}
-        <li>
-            <a href="{{ release.version }}">{{ release.title }}</a>
-        </li>
-    {% endfor %}
-    </ul>
-{% else %}
-    <li>N/A</li>
-{% endfor %}
 
-<h3>Development</h3>
-{% assign series_list = site.releases |
-    where: "draft", true |
-    sort: "series" | reverse | group_by: "series" %}
-<ul>
-{% for series in series_list %}
-    {% for release in series.items %}
+    {% assign release_list = site.releases |
+        where: "series", series |
+        where: "draft", false |
+        sort: "date" | reverse %}
+    {% assign stable_list = release_list |
+        where: "snapshot", false %}
+
+    {% if stable_list == empty %}
+        {% assign release_list = release_list | slice: 0, 1 %}
+    {% else %}
+        {% assign release_list = stable_list %}
+    {% endif %}
+
+    {% for release in release_list %}
         <li>
-            <a href="{{ release.parent.slug }}">
-                {{ release.parent.title }}
-            </a>
+            <a href="{{ release.slug }}">{{ release.title }}</a>
         </li>
     {% endfor %}
-{% else %}
-    <li>N/A</li>
+
+    </ul>
 {% endfor %}
-</ul>
 
 <h3>POPT</h3>
 <ul>

--- a/releases/index.html
+++ b/releases/index.html
@@ -7,7 +7,7 @@ title: rpm.org - Releases
 
 <h2>Releases</h2>
 
-{% for series in project.stable %}
+{% for series in project.series %}
     <h4>{{ project.title }} {{ series }}</h4>
     <ul>
 


### PR DESCRIPTION
Adapt the release indexes (on the **Releases** and **Documentation** pages) to the new RPM release model. Also add the 6.1.x entry to both. Details in the commits.

Preview: https://dmnks.github.io/rpm-web/